### PR TITLE
Feature/nvimcolemak

### DIFF
--- a/users/profiles/neovim/default.nix
+++ b/users/profiles/neovim/default.nix
@@ -43,6 +43,7 @@ in {
       require "plugins"
       require "keymaps"
       require "commands"
+      require "colemak"
     '';
     plugins = with pkgs.vimPlugins; [
       CopilotChat-nvim

--- a/users/profiles/neovim/lua/colemak.lua
+++ b/users/profiles/neovim/lua/colemak.lua
@@ -1,0 +1,37 @@
+local wk = require('which-key')
+
+-- Initially following maps are remapped
+-- L -> E -> K -> N -> J -> M -> H -> I -> L
+wk.register({
+	h = { '<left>', 'Left' },
+	H = { 'H', 'Top line of window' },
+
+	u = { 'i', 'Insert' },
+	U = { 'I', 'Insert at line start' },
+
+	n = {
+		[[(v:count > 1 ? "m'" . v:count : '') . '<down>']],
+		'Down',
+		expr = true,
+	},
+	N = { 'J', 'Join below line' },
+
+	k = { 'n', 'Find next' },
+	K = { 'N', 'Find previous' },
+
+	e = { [[(v:count > 1 ? "m'" . v:count : '') . '<up>']], 'Up', expr = true },
+	E = { 'K', 'Keyword lookup' },
+
+	f = { 'e', 'Next end of word' },
+	F = { 'E', 'Last char before white space' },
+
+	i = { '<right>', 'Right' },
+	I = { 'L', 'Last line of window' },
+
+	m = { 'm', 'Create mark' },
+	M = { 'M', 'Middle line of window' },
+
+	['<c-i>'] = { '<c-i>', 'Jump to previous jump point' },
+}, {
+	mode = { 'n', 'x', 'o' },
+})

--- a/users/profiles/neovim/lua/settings.lua
+++ b/users/profiles/neovim/lua/settings.lua
@@ -35,7 +35,6 @@ opt.listchars = {
   precedes = "←",
   extends = "→",
   nbsp = "+",
-  eol = "↲",
 }
 
 opt.fillchars = { eob = " ", diff = "" }


### PR DESCRIPTION
This pull request includes several changes to the Neovim configuration files to add support for Colemak keybindings and adjust some settings. The most important changes include adding a new module for Colemak keybindings, requiring this module in the main configuration, and modifying the `listchars` setting.

### Keybinding Enhancements:

* [`users/profiles/neovim/lua/colemak.lua`](diffhunk://#diff-c212731ec6145f4e7bf987637b9c4b786daf97cad4b775114b5edf5bfed2885eR1-R37): Added a new module that remaps various keys to support the Colemak layout using the `which-key` plugin. This includes remapping navigation keys and other frequently used keys.

### Configuration Updates:

* [`users/profiles/neovim/default.nix`](diffhunk://#diff-8a7cd3c8fb058fb5e0338c82636bc8d7f766b816cd003572ad154b302d80e566R46): Updated the main configuration to require the newly added `colemak` module.

### Settings Adjustments:

* [`users/profiles/neovim/lua/settings.lua`](diffhunk://#diff-72171592fb053e0e9b4f527ff49c0bf58d7ea0c909e2bf065b5a4926d0bb6316L38): Modified the `listchars` setting by removing the `eol` character configuration.