### PR TITLE
Add vesktop to installed packages and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,7 @@ Brown magic
 
 ### Discord things
 
-Since NixOS patches the discord binary, [Krisp yeetus deletus itself](https://nixos.wiki/wiki/Discord#Krisp_noise_suppression). Flatpak is used instead.
-
-* ```flatpak install discord```
-
+Since NixOS patches the discord binary, [Krisp yeetus deletus itself](https://nixos.wiki/wiki/Discord#Krisp_noise_suppression). Vesktop is used instead.
 
 ### Build on Mac
 

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -24,6 +24,7 @@ in {
     wl-clipboard
     wl-clipboard-x11
     xdg-utils
+    vesktop
   ];
 
   xdg.configFile."wpaperd/wallpaper.toml".source = pkgs.writeText "wallpaper.toml" ''


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `users/profiles/workstation.nix` files to replace the use of Flatpak with Vesktop.

Changes to documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R63): Updated the instructions to indicate that Vesktop is used instead of Flatpak for Discord on NixOS.

Changes to configuration:

* [`users/profiles/workstation.nix`](diffhunk://#diff-50e5a3621d610ec5dd15b2b918f7dae8d1c0c50ff9c4a051a4ef5de5932ce4fcR27): Added `vesktop` to the list of packages.