### PR TITLE
Vesktop - State and hyprland class

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -41,6 +41,7 @@
         ".config/bruno"
         ".config/chromium"
         ".config/discord"
+        ".config/vesktop"
         ".config/easyeffects"
         ".config/gcloud"
         ".config/gh"

--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -143,7 +143,7 @@ in {
     windowrulev2=workspace 4,class:(org.telegram.desktop)
     windowrulev2=workspace 4,class:(Signal)
 
-    windowrulev2=workspace 7,class:(discord)
+    windowrulev2=workspace 7,class:(vesktop)
 
     windowrulev2=workspace 4,class:(Spotify)
   '';


### PR DESCRIPTION
This pull request includes updates to configuration files to support the addition of a new application, `vesktop`, and to adjust workspace rules accordingly.

Configuration updates:

* [`profiles/state.nix`](diffhunk://#diff-c5fb2e5a58c45374ca009e2bc785dd783bc7a698c893fdfb4afc2496c16c6603R44): Added `.config/vesktop` to the list of configuration directories.
* [`users/profiles/hyprland.nix`](diffhunk://#diff-a7299bdaca443eb29bdd665691a5b375c5761479895484b8cc628a463860726aL146-R146): Changed the workspace rule for the `vesktop` application to use workspace 7 instead of `discord`.