### PR TITLE
Clipboard only snipping

### DIFF
--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -6,10 +6,9 @@
 }: let
   screenshot = pkgs.writeShellApplication {
     name = "screenshot";
-    runtimeInputs = [pkgs.slurp pkgs.grim];
+    runtimeInputs = [pkgs.hyprshot];
     text = ''
-      mkdir -p ~/Pictures/screenshots
-      slurp | grim -g - ~/Pictures/screenshots/"$(date +'%Y-%m-%dT%H%M%S.png')"
+      hyprshot -m region --clipboard-only
     '';
   };
 


### PR DESCRIPTION
This pull request includes a small change to the `users/profiles/hyprland.nix` file. The change modifies the screenshot application to use `hyprshot` instead of `slurp` and `grim`, and updates the command to capture a region and copy it to the clipboard.

* [`users/profiles/hyprland.nix`](diffhunk://#diff-a7299bdaca443eb29bdd665691a5b375c5761479895484b8cc628a463860726aL9-R11): Replaced `slurp` and `grim` with `hyprshot` for the screenshot application and updated the command to use `hyprshot -m region --clipboard-only`.