### PR TITLE
Add VSCodium

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -1,4 +1,5 @@
-{adminUser, ...}: {
+{ adminUser, ... }:
+{
   environment.persistence."/keep" = {
     hideMounts = true;
     directories = [
@@ -52,6 +53,7 @@
         ".config/pipewire"
         ".config/pulse"
         ".config/spotify"
+        ".config/VSCodium"
         ".config/warcraftlogs"
         ".factorio"
         ".gnupg"
@@ -63,6 +65,7 @@
         ".local/share/fish"
         ".local/share/flatpak"
         ".local/share/lutris"
+        ".local/share/keyrings"
         ".local/share/nix"
         ".local/share/vulkan"
         ".local/share/zoxide"
@@ -81,7 +84,7 @@
         "Pictures"
         "code"
         "git"
-	".ssh"
+        ".ssh"
       ];
       files = [
         ".cockroachsql_history"

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -4,7 +4,8 @@
   pkgs,
   inputs,
   ...
-}: {
+}:
+{
   imports = [
     ./defaults.nix
     inputs.nixos-hardware.nixosModules.common-pc-ssd
@@ -19,27 +20,30 @@
   hardware.graphics.enable = true;
   hardware.graphics.enable32Bit = true;
 
-  hardware.graphics.extraPackages = [];
+  hardware.graphics.extraPackages = [ ];
 
-  hardware.graphics.extraPackages32 = [];
+  hardware.graphics.extraPackages32 = [ ];
 
   security.rtkit.enable = true;
   hardware.bluetooth.enable = true;
   networking.wireless.iwd.enable = true;
 
-  environment.pathsToLink = ["/etc/gconf"];
+  environment.pathsToLink = [ "/etc/gconf" ];
 
   security.pam.services.swaylock = {
     text = ''
       auth include login
     '';
   };
-  security.pam.services.hyprlock = {};
+  security.pam.services.hyprlock = { };
+
+  security.pam.services.gdm.enableGnomeKeyring = true; # load gnome-keyring at startup
+  programs.seahorse.enable = true; # enable the graphical frontend for managing
 
   powerManagement.enable = true;
   powerManagement.powertop.enable = true;
 
-  environment.persistence."/keep".directories = ["/var/cache/powertop"];
+  environment.persistence."/keep".directories = [ "/var/cache/powertop" ];
 
   virtualisation.docker.enable = false;
   virtualisation.podman.enable = true;
@@ -59,8 +63,12 @@
 
   services.fwupd.enable = true;
 
-  services.dbus.packages = with pkgs; [gcr dconf sushi];
-  services.udev.packages = with pkgs; [gnome-settings-daemon];
+  services.dbus.packages = with pkgs; [
+    gcr
+    dconf
+    sushi
+  ];
+  services.udev.packages = with pkgs; [ gnome-settings-daemon ];
 
   services.pipewire = {
     enable = true;
@@ -85,19 +93,24 @@
   xdg.portal = {
     enable = true;
     wlr.enable = true;
-    extraPortals = [pkgs.xdg-desktop-portal-gtk];
-    config = let
-      wlrConf = {
-        default = ["wlr" "gtk"];
-        "org.freedesktop.impl.portal.Secret" = ["gnome-keyring"];
+    extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+    config =
+      let
+        wlrConf = {
+          default = [
+            "wlr"
+            "gtk"
+          ];
+          "org.freedesktop.impl.portal.Secret" = [ "gnome-keyring" ];
+        };
+      in
+      {
+        common = {
+          default = [ "gtk" ];
+          "org.freedesktop.impl.portal.Secret" = [ "gnome-keyring" ];
+        };
+        sway = wlrConf;
       };
-    in {
-      common = {
-        default = ["gtk"];
-        "org.freedesktop.impl.portal.Secret" = ["gnome-keyring"];
-      };
-      sway = wlrConf;
-    };
   };
 
   fonts.packages = with pkgs; [

--- a/users/profiles/gnome-keyring.nix
+++ b/users/profiles/gnome-keyring.nix
@@ -1,5 +1,5 @@
 # GNOME Keyring for storing/encrypting secrets
-# apps like vscode stores encrypted data using it
+# Apps like VSCode store encrypted data using it
 
 {
   services.gnome-keyring.enable = true;

--- a/users/profiles/gnome-keyring.nix
+++ b/users/profiles/gnome-keyring.nix
@@ -1,4 +1,4 @@
-# GNOME Keyring for storing/encrypting sycrets
+# GNOME Keyring for storing/encrypting secrets
 # apps like vscode stores encrypted data using it
 
 {

--- a/users/profiles/gnome-keyring.nix
+++ b/users/profiles/gnome-keyring.nix
@@ -1,0 +1,6 @@
+# GNOME Keyring for storing/encrypting sycrets
+# apps like vscode stores encrypted data using it
+
+{
+  services.gnome-keyring.enable = true;
+}

--- a/users/profiles/vscodium.nix
+++ b/users/profiles/vscodium.nix
@@ -5,17 +5,17 @@
     package = pkgs.vscodium;
     profiles.default = {
       extensions = with pkgs.vscode-extensions; [
-        jnoortheen.nix-ide
-        redhat.vscode-yaml
-        vscodevim.vim
-        github.github-vscode-theme
+        eamodio.gitlens
+        fill-labs.dependi
         github.copilot
         github.copilot-chat
-        vadimcn.vscode-lldb
-        fill-labs.dependi
-        usernamehw.errorlens
-        eamodio.gitlens
+        github.github-vscode-theme
+        jnoortheen.nix-ide
+        redhat.vscode-yaml
         rust-lang.rust-analyzer
+        usernamehw.errorlens
+        vadimcn.vscode-lldb
+        vscodevim.vim
       ];
       userSettings = {
         "editor.formatOnSave" = true;

--- a/users/profiles/vscodium.nix
+++ b/users/profiles/vscodium.nix
@@ -1,0 +1,33 @@
+{ pkgs, ... }:
+{
+  programs.vscode = {
+    enable = true;
+    package = pkgs.vscodium;
+    profiles.default = {
+      extensions = with pkgs.vscode-extensions; [
+        jnoortheen.nix-ide
+        redhat.vscode-yaml
+        vscodevim.vim
+        github.github-vscode-theme
+        github.copilot
+        github.copilot-chat
+        vadimcn.vscode-lldb
+        fill-labs.dependi
+        usernamehw.errorlens
+        eamodio.gitlens
+        rust-lang.rust-analyzer
+      ];
+      userSettings = {
+        "editor.formatOnSave" = true;
+        "diffEditor.hideUnchangedRegions.enabled" = true;
+        "git.autofetch" = true;
+        "git.confirmSync" = false;
+        "redhat.telemetry.enabled" = false;
+        "workbench.colorTheme" = "GitHub Dark Default";
+        "workbench.sideBar.location" = "right";
+        "lldb.suppressUpdateNotifications" = true;
+        "editor.lineNumbers" = "relative";
+      };
+    };
+  };
+}

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -2,15 +2,19 @@
   pkgs,
   config,
   ...
-}: let
+}:
+let
   inherit (config) gtk;
-in {
+in
+{
   imports =
-    [./default.nix]
+    [ ./default.nix ]
     ++ [
       ./hyprland.nix
       ./rofi.nix
       ./waybar.nix
+      ./vscodium.nix
+      ./gnome-keyring.nix
     ];
 
   home.packages = with pkgs; [
@@ -19,12 +23,14 @@ in {
     scrot
     signal-desktop
     spotify
-    tdesktop ## Telegram
+    tdesktop # # Telegram
     vulkan-loader
     wl-clipboard
     wl-clipboard-x11
     xdg-utils
     vesktop
+    nixfmt-rfc-style
+    libsecret
   ];
 
   xdg.configFile."wpaperd/wallpaper.toml".source = pkgs.writeText "wallpaper.toml" ''
@@ -66,7 +72,8 @@ in {
     };
   };
 
-  home.file."Pictures/wallpapers/default-background.jpg".source = "${pkgs.adapta-backgrounds}/share/backgrounds/adapta/tri-fadeno.jpg";
+  home.file."Pictures/wallpapers/default-background.jpg".source =
+    "${pkgs.adapta-backgrounds}/share/backgrounds/adapta/tri-fadeno.jpg";
 
   base16-theme.enable = true;
 


### PR DESCRIPTION
This pull request introduces several changes to improve configuration management and enhance user experience across workstation and user profiles. Key updates include enabling GNOME Keyring, configuring VSCodium with extensions and user settings, and refining formatting and organization in Nix files.

### Configuration Enhancements:
* [`users/profiles/gnome-keyring.nix`](diffhunk://#diff-820c6d99bf9ea16a0f055b65a44f29c28919402c12364fc5e5a9e8f72038fc2fR1-R6): Added GNOME Keyring configuration to enable secure storage of secrets and integration with applications like VSCode.
* [`users/profiles/vscodium.nix`](diffhunk://#diff-49cfa9755d5d924d70746651a9dd33385b260ce281f56f23d7ff54f2a796f717R1-R33): Configured VSCodium with a set of extensions (e.g., GitHub Copilot, Rust Analyzer) and user settings for improved development workflows.

### Formatting and Organizational Improvements:
* `profiles/state.nix` and `profiles/workstation.nix`: Improved formatting by adding consistent spacing and indentation across configuration blocks. [[1]](diffhunk://#diff-c5fb2e5a58c45374ca009e2bc785dd783bc7a698c893fdfb4afc2496c16c6603L1-R2) [[2]](diffhunk://#diff-0d8740e2c4c27c8e865cf6ba290a303fba54ad1861ab5132fba737274dcd3479L62-R70) [[3]](diffhunk://#diff-0d8740e2c4c27c8e865cf6ba290a303fba54ad1861ab5132fba737274dcd3479L89-R107)
* [`users/profiles/workstation.nix`](diffhunk://#diff-50e5a3621d610ec5dd15b2b918f7dae8d1c0c50ff9c4a051a4ef5de5932ce4fcL5-R17): Refined imports and added new tools (`vscodium.nix`, `gnome-keyring.nix`, `nixfmt-rfc-style`, `libsecret`) to enhance functionality. [[1]](diffhunk://#diff-50e5a3621d610ec5dd15b2b918f7dae8d1c0c50ff9c4a051a4ef5de5932ce4fcL5-R17) [[2]](diffhunk://#diff-50e5a3621d610ec5dd15b2b918f7dae8d1c0c50ff9c4a051a4ef5de5932ce4fcR32-R33)

### Additional Updates:
* [`profiles/state.nix`](diffhunk://#diff-c5fb2e5a58c45374ca009e2bc785dd783bc7a698c893fdfb4afc2496c16c6603R56): Added new directories to the persistence configuration, such as `.config/VSCodium` and `.local/share/keyrings`, for better application support. [[1]](diffhunk://#diff-c5fb2e5a58c45374ca009e2bc785dd783bc7a698c893fdfb4afc2496c16c6603R56) [[2]](diffhunk://#diff-c5fb2e5a58c45374ca009e2bc785dd783bc7a698c893fdfb4afc2496c16c6603R68)