### PR TITLE
Add dark mode to rofi

### DIFF
--- a/users/profiles/rofi.nix
+++ b/users/profiles/rofi.nix
@@ -1,7 +1,9 @@
-{pkgs, ...}: {
+{ pkgs, ... }:
+{
   programs.rofi = {
     enable = true;
     package = pkgs.rofi-wayland;
     font = "monofur 13";
+    theme = "Arc-Dark";
   };
 }


### PR DESCRIPTION
This pull request updates the `users/profiles/rofi.nix` file to improve readability and enhance the configuration for the Rofi program.

Enhancements to Rofi configuration:

* Added a `theme` property to set the Rofi theme to "Arc-Dark."

Code readability improvements:

* Adjusted spacing in the function parameter declaration for better readability.