### PR TITLE
Enable git autoSetupRemote

### DIFF
--- a/users/profiles/git.nix
+++ b/users/profiles/git.nix
@@ -1,4 +1,5 @@
-{pkgs, ...}: {
+{ pkgs, ... }:
+{
   programs.git = {
     enable = true;
     delta = {
@@ -18,11 +19,12 @@
         editor = "nvim";
         whitespace = "cr-at-eol";
       };
-#      gpg.format = "ssh";
-#      commit.gpgSign = true;
+      #      gpg.format = "ssh";
+      #      commit.gpgSign = true;
       tag.forceSignAnnotated = true;
       init.defaultBranch = "main";
       pull.rebase = true;
+      push.autoSetupRemote = "true";
       push.default = "simple";
       push.followTags = "true";
       color = {


### PR DESCRIPTION
This pull request includes changes to the `users/profiles/git.nix` file to improve Git configuration settings.

Git configuration updates:

* Fixed formatting in the argument list by adding a space after the comma in `{ pkgs, ... }`.
* Added `push.autoSetupRemote = "true";` to automatically set up tracking branches when pushing to a remote.