### PR TITLE
Feature/vs usersetting startup editor

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -76,6 +76,7 @@
         ".steam"
         ".terraform.d"
         ".var"
+        ".vscode-oss"
         ".wine"
         "Documents"
         "Downloads"

--- a/users/profiles/vscodium.nix
+++ b/users/profiles/vscodium.nix
@@ -18,15 +18,16 @@
         vscodevim.vim
       ];
       userSettings = {
-        "editor.formatOnSave" = true;
         "diffEditor.hideUnchangedRegions.enabled" = true;
+        "editor.formatOnSave" = true;
+        "editor.lineNumbers" = "relative";
         "git.autofetch" = true;
         "git.confirmSync" = false;
+        "lldb.suppressUpdateNotifications" = true;
         "redhat.telemetry.enabled" = false;
         "workbench.colorTheme" = "GitHub Dark Default";
         "workbench.sideBar.location" = "right";
-        "lldb.suppressUpdateNotifications" = true;
-        "editor.lineNumbers" = "relative";
+        "workbench.startupEditor": "none"
       };
     };
   };


### PR DESCRIPTION
This pull request introduces updates to configuration files to enhance user settings and directory management. The most notable changes include adding `.vscode-oss` to the list of ignored directories and reorganizing and expanding user settings for VSCodium.

### Directory Management Updates:
* [`profiles/state.nix`](diffhunk://#diff-c5fb2e5a58c45374ca009e2bc785dd783bc7a698c893fdfb4afc2496c16c6603R79): Added `.vscode-oss` to the list of ignored directories, ensuring it is excluded from certain operations.

### VSCodium User Settings Enhancements:
* [`users/profiles/vscodium.nix`](diffhunk://#diff-49cfa9755d5d924d70746651a9dd33385b260ce281f56f23d7ff54f2a796f717L21-R30): Reorganized user settings for clarity and added new configurations, including enabling relative line numbers (`editor.lineNumbers`), suppressing LLDB update notifications (`lldb.suppressUpdateNotifications`), and setting the startup editor to "none" (`workbench.startupEditor`).