### PR TITLE
Add .vscode-oss folder to state

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -76,6 +76,7 @@
         ".steam"
         ".terraform.d"
         ".var"
+        ".vscode-oss"
         ".wine"
         "Documents"
         "Downloads"


### PR DESCRIPTION
This pull request includes a small change to the `profiles/state.nix` file. The change adds `.vscode-oss` to the list of directories.