### PR TITLE
Enable libvirtd

### DIFF
--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -46,8 +46,26 @@
   environment.persistence."/keep".directories = [ "/var/cache/powertop" ];
 
   virtualisation.docker.enable = false;
-  virtualisation.podman.enable = true;
-  virtualisation.podman.dockerCompat = true;
+  virtualisation.podman.enable = false;
+  virtualisation.podman.dockerCompat = false;
+
+  virtualisation.libvirtd = {
+    enable = true;
+    qemu = {
+      package = pkgs.qemu_kvm;
+      runAsRoot = true;
+      swtpm.enable = true;
+      ovmf = {
+        enable = true;
+        packages = [
+          (pkgs.OVMF.override {
+            secureBoot = true;
+            tpmSupport = true;
+          }).fd
+        ];
+      };
+    };
+  };
 
   programs.ssh.startAgent = true;
 

--- a/users/profiles/default.nix
+++ b/users/profiles/default.nix
@@ -1,7 +1,8 @@
 {
   pkgs,
   ...
-}:{
+}:
+{
   imports = [
     ./alacritty.nix
     ./bat.nix
@@ -24,6 +25,8 @@
     lm_sensors
     nix-index
     p7zip
+    virt-manager
+    virt-viewer
   ];
 
   xdg.enable = true;
@@ -52,7 +55,7 @@
       OnCalendar = "*-*-* 4:00:00";
       Unit = "nix-index.service";
     };
-    Install.WantedBy = ["timers.target"];
+    Install.WantedBy = [ "timers.target" ];
   };
 
   home.stateVersion = "21.05";


### PR DESCRIPTION
This pull request makes changes to virtualization settings and user profiles in a Nix configuration. The most significant updates involve switching from Podman to libvirtd for virtualization, adding virtualization-related packages, and fixing a minor syntax issue in the user profile definition.

### Virtualization Updates:
* [`profiles/workstation.nix`](diffhunk://#diff-0d8740e2c4c27c8e865cf6ba290a303fba54ad1861ab5132fba737274dcd3479L49-R68): Disabled Podman (`virtualisation.podman.enable` and `virtualisation.podman.dockerCompat`) and enabled libvirtd with QEMU KVM, secure boot, TPM support, and OVMF configuration for virtualization.

### User Profile Updates:
* [`users/profiles/default.nix`](diffhunk://#diff-a9439bb0989edf1b431bed7375969658b9b383cd7682bc82f5e70c5cc0721233R28-R29): Added `virt-manager` and `virt-viewer` to the list of installed packages to support virtualization management tools.
* [`users/profiles/default.nix`](diffhunk://#diff-a9439bb0989edf1b431bed7375969658b9b383cd7682bc82f5e70c5cc0721233L4-R5): Fixed a minor syntax issue by adding a newline after the closing bracket of function arguments.