### PR TITLE
Enable nvidia-beta drivers

### DIFF
--- a/profiles/hardware/nvidia.nix
+++ b/profiles/hardware/nvidia.nix
@@ -1,13 +1,13 @@
 {
   config,
   ...
-}: 
+}:
 {
   hardware.graphics = {
     enable = true;
   };
 
-  services.xserver.videoDrivers = ["nvidia"];
+  services.xserver.videoDrivers = [ "nvidia" ];
 
   hardware.nvidia = {
     open = true;
@@ -15,6 +15,7 @@
     powerManagement.enable = false;
     powerManagement.finegrained = false;
     nvidiaSettings = true;
+    package = config.boot.kernelPackages.nvidiaPackages.beta;
   };
 
   #boot.initrd.kernelModules = [ "nvidia" ];


### PR DESCRIPTION
This pull request updates the NVIDIA hardware profile configuration to use the beta version of the NVIDIA driver package.

* [`profiles/hardware/nvidia.nix`](diffhunk://#diff-3d6c78a12193b2a61da1655c76121bef7ae85f33facd7fb0b7f232011add60ceR18): Added a new line to set the `package` attribute to `config.boot.kernelPackages.nvidiaPackages.beta`, enabling the use of the beta NVIDIA driver package.