### PR TITLE
Add iso host-profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 * ```nixos-rebuild build --flake .#$hostname ```
 
 ### Switch to build
-* ```nixos-rebuild switch --flake .#$hostname --use-remote-sudo```
+* ```nixos-rebuild switch --flake .#$hostname --sudo```
 
 ### Build on Mac
 
@@ -46,6 +46,13 @@ https://github.com/DeterminateSystems/nix-installer
 
 * ```nix build .#nixosConfigurations.nixbox.config.system.build.toplevel```
     * *Remember that building x86 on arm64 is really hard...*
+
+### Create iso
+
+```shell
+cd $repo
+nix-build '<nixpkgs/nixos>' -A config.system.build.isoImage -I nixos-config=hosts/x86_64-linux/installer.nix
+```
 
 ## Wow things
 

--- a/hosts/x86_64-linux/installer.nix
+++ b/hosts/x86_64-linux/installer.nix
@@ -1,0 +1,58 @@
+{
+  pkgs,
+  modulesPath,
+  lib,
+  ...
+}:
+{
+  imports = [
+    "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
+  ];
+  services.openssh.enable = true;
+  i18n.defaultLocale = "en_US.UTF-8";
+  console.keyMap = "us";
+  time.timeZone = "Europe/Stockholm";
+  boot.kernelParams = [ "console=ttyS0" ];
+  boot.loader.timeout = lib.mkForce 1;
+  boot.loader.efi.canTouchEfiVariables = true;
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.initrd.availableKernelModules = [
+    "xhci_pci"
+    "nvme"
+    "usb_storage"
+    "sd_mod"
+    "rtsx_pci_sdmmc"
+  ];
+  boot.supportedFilesystems = lib.mkForce [
+    "btrfs"
+    "cifs"
+    "f2fs"
+    "jfs"
+    "ntfs"
+    "reiserfs"
+    "vfat"
+    "xfs"
+    "bcachefs"
+  ];
+  users.users.root.openssh.authorizedKeys.keys = [
+    "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIGWqiT3pihX88HrCvpnnsWANv3RJm5SdMJwZkRHpfHj5AAAABHNzaDo= nemko@nixbox"
+  ];
+
+  nix = {
+    settings.trusted-users = [ "root" ];
+    extraOptions = ''
+      experimental-features = nix-command flakes
+      keep-outputs = true
+      keep-derivations = true
+      tarball-ttl = 900
+    '';
+  };
+
+  environment.systemPackages = with pkgs; [
+    git
+    nixos-install-tools
+    bcachefs-tools
+    btrfs-progs
+    jq
+  ];
+}


### PR DESCRIPTION
This pull request introduces updates to the documentation and adds a new NixOS configuration for creating an installer ISO. The key changes include modifying existing commands in the `README.md`, adding instructions for creating an ISO, and implementing a new NixOS configuration file for the installer.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R41): Updated the `nixos-rebuild switch` command to replace `--use-remote-sudo` with `--sudo` for clarity and consistency.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R56): Added a new section with instructions for creating an ISO image using `nix-build` and a specified configuration file.

### NixOS Installer Configuration:
* [`hosts/x86_64-linux/installer.nix`](diffhunk://#diff-f341b1878b9b82f580f63935048820a7feeb9863ca496c808e7f145c2af0051dR1-R58): Added a new configuration file for creating a minimal NixOS installer ISO. This includes enabling OpenSSH, setting locale and timezone, configuring kernel parameters, specifying supported filesystems, and defining system packages and Nix settings.