### PR TITLE
Disable libvirtd

### DIFF
--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -50,7 +50,7 @@
   virtualisation.podman.dockerCompat = false;
 
   virtualisation.libvirtd = {
-    enable = true;
+    enable = false;
     qemu = {
       package = pkgs.qemu_kvm;
       runAsRoot = true;


### PR DESCRIPTION
This pull request includes a small change to the `profiles/workstation.nix` file. The change disables the `libvirtd` service by setting its `enable` property to `false` instead of `true` to adjust virtualization settings.