### PR TITLE
Feature/initial lutris

### DIFF
--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -5,15 +5,21 @@
   config,
   lib,
   ...
-}: let
-  inherit (lib // builtins) attrNames hasAttr mkIf length;
+}:
+let
+  inherit (lib // builtins)
+    attrNames
+    hasAttr
+    mkIf
+    length
+    ;
   hasState =
-    hasAttr "persistence" config.environment
-    && (length (attrNames config.environment.persistence)) > 0;
-  hasSecrets = config.age.secrets != {};
-in {
+    hasAttr "persistence" config.environment && (length (attrNames config.environment.persistence)) > 0;
+  hasSecrets = config.age.secrets != { };
+in
+{
   nix = {
-    settings.trusted-users = ["root"];
+    settings.trusted-users = [ "root" ];
     extraOptions = ''
       experimental-features = nix-command flakes
       keep-outputs = true
@@ -21,7 +27,7 @@ in {
       tarball-ttl = 900
     '';
 
-    nixPath = ["nixpkgs=${inputs.nixpkgs}"];
+    nixPath = [ "nixpkgs=${inputs.nixpkgs}" ];
 
     gc = {
       automatic = true;
@@ -32,46 +38,45 @@ in {
     package = pkgs.nix;
   };
 
-  environment.systemPackages =
-    [
-      pkgs.binutils
-      pkgs.blueman
-      pkgs.bmon
-      pkgs.bottom
-      pkgs.bridge-utils
-      pkgs.cacert
-      pkgs.curl
-      pkgs.fd
-      pkgs.file
-      pkgs.fish
-      pkgs.git
-      pkgs.gnupg
-      pkgs.btop
-      pkgs.hyperfine
-      pkgs.iftop
-      pkgs.iptables
-      pkgs.jq
-      pkgs.lsof
-      pkgs.man-pages
-      pkgs.mkpasswd
-      pkgs.nmap
-      pkgs.openssl
-      pkgs.pavucontrol
-      pkgs.pciutils
-      pkgs.powertop
-      pkgs.procs
-      pkgs.psmisc
-      pkgs.ripgrep
-      pkgs.sd
-      pkgs.socat
-      pkgs.tmux
-      pkgs.tree
-      pkgs.unzip
-      pkgs.usbutils
-      pkgs.vim
-      pkgs.wget
-      pkgs.zip
-    ];
+  environment.systemPackages = [
+    pkgs.binutils
+    pkgs.blueman
+    pkgs.bmon
+    pkgs.bottom
+    pkgs.bridge-utils
+    pkgs.cacert
+    pkgs.curl
+    pkgs.fd
+    pkgs.file
+    pkgs.fish
+    pkgs.git
+    pkgs.gnupg
+    pkgs.btop
+    pkgs.hyperfine
+    pkgs.iftop
+    pkgs.iptables
+    pkgs.jq
+    pkgs.lsof
+    pkgs.man-pages
+    pkgs.mkpasswd
+    pkgs.nmap
+    pkgs.openssl
+    pkgs.pavucontrol
+    pkgs.pciutils
+    pkgs.powertop
+    pkgs.procs
+    pkgs.psmisc
+    pkgs.ripgrep
+    pkgs.sd
+    pkgs.socat
+    pkgs.tmux
+    pkgs.tree
+    pkgs.unzip
+    pkgs.usbutils
+    pkgs.vim
+    pkgs.wget
+    pkgs.zip
+  ];
 
   home-manager.useUserPackages = true;
   home-manager.useGlobalPkgs = true;
@@ -79,7 +84,15 @@ in {
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
   boot.kernelPackages = pkgs.linuxPackages_latest;
-  boot.initrd.availableKernelModules = ["xhci_pci" "nvme" "ahci" "usbhid" "usb_storage" "sd_mod" "rtsx_pci_sdmmc"];
+  boot.initrd.availableKernelModules = [
+    "xhci_pci"
+    "nvme"
+    "ahci"
+    "usbhid"
+    "usb_storage"
+    "sd_mod"
+    "rtsx_pci_sdmmc"
+  ];
 
   i18n.defaultLocale = "en_US.UTF-8";
   console.keyMap = "us";
@@ -94,7 +107,11 @@ in {
     }
   ];
 
-  environment.shells = [pkgs.bashInteractive pkgs.zsh pkgs.fish];
+  environment.shells = [
+    pkgs.bashInteractive
+    pkgs.zsh
+    pkgs.fish
+  ];
 
   programs.fish.enable = true;
 
@@ -120,7 +137,9 @@ in {
 
   system.stateVersion = "24.05";
 
-  system.activationScripts.agenixNewGeneration = mkIf (hasSecrets && hasState) {deps = ["persist-files"];};
+  system.activationScripts.agenixNewGeneration = mkIf (hasSecrets && hasState) {
+    deps = [ "persist-files" ];
+  };
 
   services.nix-dirs.enable = true;
 }

--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -90,7 +90,7 @@ in {
       domain = "*";
       type = "-";
       item = "nofile";
-      value = "16384";
+      value = "524288";
     }
   ];
 

--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -321,6 +321,8 @@ in
       "[workspace 4 silent] ${pkgs.signal-desktop}/bin/signal-desktop"
       "[workspace 4 silent] ${pkgs.tdesktop}/bin/Telegram"
       "[workspace 4 silent] ${pkgs.spotify}/bin/spotify"
+      "[workspace 5 silent] ${pkgs.steam}/bin/steam"
+      "[workspace 5 silent] ${pkgs.lutris}/bin/lutris"
       "[workspace 7 silent] ${pkgs.vesktop}/bin/vesktop"
     ];
   };

--- a/users/profiles/lutris.nix
+++ b/users/profiles/lutris.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+{
+  programs.lutris = {
+    enable = true;
+    protonPackages = with pkgs; [
+      proton-ge-bin
+    ];
+  };
+}

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -11,6 +11,7 @@ in
     [ ./default.nix ]
     ++ [
       ./hyprland.nix
+      ./lutris.nix
       ./rofi.nix
       ./waybar.nix
       ./vscodium.nix


### PR DESCRIPTION
This pull request makes several improvements to the Nix configuration files, focusing on code formatting, system configuration enhancements, and new feature additions. The most notable changes include reformatting code for better readability, increasing the file descriptor limit, and adding support for Lutris and Steam in specific user profiles.

### Code Formatting Improvements:
* Reformatted attribute inheritance and list definitions in `profiles/defaults.nix` for improved readability and consistency. For example, lists such as `environment.systemPackages` and `boot.initrd.availableKernelModules` were updated to use multi-line formatting. [[1]](diffhunk://#diff-b0f4b98e23642e037cea1e2291053bd6978271ce32f253ba0e7fa766a5ad8da1L8-R20) [[2]](diffhunk://#diff-b0f4b98e23642e037cea1e2291053bd6978271ce32f253ba0e7fa766a5ad8da1L35-R41) [[3]](diffhunk://#diff-b0f4b98e23642e037cea1e2291053bd6978271ce32f253ba0e7fa766a5ad8da1L82-R95) [[4]](diffhunk://#diff-b0f4b98e23642e037cea1e2291053bd6978271ce32f253ba0e7fa766a5ad8da1L93-R114)

### System Configuration Enhancements:
* Increased the file descriptor limit (`nofile`) from `16384` to `524288` in the `profiles/defaults.nix` configuration. This change improves system performance for applications requiring a higher limit.
* Updated the `agenixNewGeneration` activation script to use multi-line formatting for better readability.

### New Features:
* Added support for Lutris gaming platform in `users/profiles/lutris.nix`, enabling the program and configuring Proton packages.
* Integrated Lutris and Steam into the Hyprland user profile, assigning them to workspace 5.
* Included the new `lutris.nix` profile in the workstation configuration by updating `users/profiles/workstation.nix`.