### PR TITLE
Add GPU powerdraw to waybar

### DIFF
--- a/users/profiles/waybar.nix
+++ b/users/profiles/waybar.nix
@@ -1,12 +1,31 @@
-{lib, ...}: {
+{ lib, ... }:
+{
   programs.waybar.enable = true;
   programs.waybar.settings.topBar = {
     bar_id = "top";
     ipc = true;
     position = "top";
-    modules-left = ["hyprland/workspaces" "sway/workspaces" "sway/mode" "hyprland/submap"];
+    modules-left = [
+      "hyprland/workspaces"
+      "sway/workspaces"
+      "sway/mode"
+      "hyprland/submap"
+    ];
     # modules-center = ["hyprland/window"];
-    modules-right = ["network" "network#wifi" "memory" "cpu" "temperature" "idle_inhibitor" "pulseaudio" "blacklight" "battery" "clock" "tray"];
+    modules-right = [
+      "custom/gpu_powerdraw"
+      "network"
+      "network#wifi"
+      "memory"
+      "cpu"
+      "temperature"
+      "idle_inhibitor"
+      "pulseaudio"
+      "blacklight"
+      "battery"
+      "clock"
+      "tray"
+    ];
     "sway/workspaces" = {
       disable-scroll-wraparound = true;
     };
@@ -19,6 +38,11 @@
     "hyprland/submap" = {
       format = "✌️ {}";
       tooltip = false;
+    };
+    "custom/gpu_powerdraw" = {
+      format = "🥵 {text}W ";
+      exec = "nvidia-smi --query-gpu=power.draw --format=csv,noheader,nounits";
+      interval = 5;
     };
     network = {
       interface = lib.mkDefault "enp*";
@@ -65,10 +89,16 @@
         phone = "";
         portable = "";
         car = "";
-        default = ["" ""];
+        default = [
+          ""
+          ""
+        ];
       };
       scroll-step = 1;
-      ignored-sinks = ["Easy Effects Sink" "SteelSeries Arctis 7 Chat"];
+      ignored-sinks = [
+        "Easy Effects Sink"
+        "SteelSeries Arctis 7 Chat"
+      ];
     };
     clock = {
       format = "{:%F %H:%M}";


### PR DESCRIPTION
This pull request updates the `waybar.nix` configuration to improve readability and functionality by reformatting lists, adding a custom GPU power draw module, and making minor stylistic adjustments. Below are the most important changes grouped by theme:

### Functional Enhancements:
* Added a new custom module, `custom/gpu_powerdraw`, to display GPU power draw in watts. This module uses `nvidia-smi` for data retrieval and updates every 5 seconds. (`[users/profiles/waybar.nixR42-R46](diffhunk://#diff-3aa934ee626c6c1e66fe0fafeec9024b175b8ec848ce80bfb45fb6f59be54050R42-R46)`)

### Code Readability and Style Improvements:
* Reformatted `modules-left`, `modules-right`, and `ignored-sinks` lists to use a multi-line format for better readability. (`[[1]](diffhunk://#diff-3aa934ee626c6c1e66fe0fafeec9024b175b8ec848ce80bfb45fb6f59be54050L1-R28)`, `[[2]](diffhunk://#diff-3aa934ee626c6c1e66fe0fafeec9024b175b8ec848ce80bfb45fb6f59be54050L68-R101)`)
* Standardized spacing in the function declaration by adding a space after the opening curly brace. (`[users/profiles/waybar.nixL1-R28](diffhunk://#diff-3aa934ee626c6c1e66fe0fafeec9024b175b8ec848ce80bfb45fb6f59be54050L1-R28)`)