### PR TITLE
Enable VMware workstation

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -86,6 +86,7 @@
         "code"
         "git"
         ".ssh"
+        "vmware"
       ];
       files = [
         ".cockroachsql_history"

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -49,6 +49,8 @@
   virtualisation.podman.enable = false;
   virtualisation.podman.dockerCompat = false;
 
+  virtualisation.vmware.host.enable = true;
+
   virtualisation.libvirtd = {
     enable = false;
     qemu = {


### PR DESCRIPTION
This pull request introduces support for VMware on the workstation profile by enabling the VMware host service and ensuring the relevant directory is persisted across system rebuilds.

Virtualization support:

* Enabled the VMware host service in the `workstation.nix` profile by setting `virtualisation.vmware.host.enable` to `true`.

State persistence:

* Added the `vmware` directory to the list of persisted directories in `state.nix` to ensure VMware-related data is retained across system rebuilds.