### PR TITLE
Set hyprland scale on DP-3 to 1.33

### DIFF
--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -144,8 +144,8 @@ in
   wayland.windowManager.hyprland.settings = {
     monitor = [
       "DP-4, preferred, 0x0, 1, transform, 1"
-      "DP-3, preferred, 1440x0, 1.5"
-      "DP-5, preferred, 4000x0, 1, transform, 3"
+      "DP-3, preferred, 1440x0, 1.33"
+      "DP-5, preferred, 4327x0, 1, transform, 3"
     ];
     "$mod" = "SUPER";
     bind = [
@@ -320,6 +320,7 @@ in
       "${pkgs.wpaperd}/bin/wpaperd"
       "${pkgs.hyprland}/bin/hyprctl setcursor ${xcursor_theme} 24"
       "${pkgs.polkit_gnome.out}/libexec/polkit-gnome-authentication-agent-1"
+      "[workspace 2 silent] ${pkgs.btop}/bin/btop"
       "[workspace 2 silent] ${pkgs.firefox}/bin/firefox"
       "[workspace 4 silent] ${pkgs.signal-desktop}/bin/signal-desktop"
       "[workspace 4 silent] ${pkgs.tdesktop}/bin/Telegram"


### PR DESCRIPTION
This pull request makes a few adjustments to the Hyprland configuration, mainly refining monitor settings and improving workspace startup applications.

Monitor configuration updates:

* Adjusted the scaling factor for `DP-3` from `1.5` to `1.33` and changed the position of `DP-5` from `4000x0` to `4327x0` in the `monitor` settings, likely to improve display alignment and scaling.

Workspace startup improvements:

* Added `btop` to automatically launch on workspace 2 in silent mode, enhancing the default set of applications started with the session.