### PR TITLE
Home-manager btop

### DIFF
--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -51,7 +51,6 @@ in
     pkgs.fish
     pkgs.git
     pkgs.gnupg
-    pkgs.btop
     pkgs.hyperfine
     pkgs.iftop
     pkgs.iptables

--- a/users/profiles/default.nix
+++ b/users/profiles/default.nix
@@ -37,6 +37,10 @@
     enable = true;
   };
 
+  programs.btop = {
+    enable = true;
+  };
+
   programs.direnv = {
     enable = true;
     nix-direnv.enable = true;


### PR DESCRIPTION
This pull request makes a minor adjustment to how the `btop` system monitoring tool is enabled for users. Instead of installing `btop` globally via the `profiles/defaults.nix`, it is now enabled per-user through the `users/profiles/default.nix` configuration.

Configuration changes:

* Removed `pkgs.btop` from the global package list in `profiles/defaults.nix`, so it is no longer installed system-wide.
* Added and enabled the `programs.btop` module in `users/profiles/default.nix`, ensuring `btop` is available for users who have this profile.