### PR TITLE
Remove systemd.extraConfig

### DIFF
--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -128,10 +128,6 @@ in
   services.sshguard.enable = true;
   services.fstrim.enable = true;
 
-  systemd.extraConfig = ''
-    DefaultTimeoutStopSec=90
-  '';
-
   users.mutableUsers = false;
 
   system.stateVersion = "24.05";


### PR DESCRIPTION
This pull request makes a minor configuration change to the `profiles/defaults.nix` file by removing the custom `DefaultTimeoutStopSec` setting from the `systemd.extraConfig` option. This means the system will now use the default stop timeout for systemd services.

- Removed the `DefaultTimeoutStopSec=90` setting from `systemd.extraConfig`, reverting to the systemd default stop timeout.