### PR TITLE
Add RuneLite

### DIFF
--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -75,6 +75,7 @@ in
     pkgs.vim
     pkgs.wget
     pkgs.zip
+    pkgs.runelite
   ];
 
   home-manager.useUserPackages = true;


### PR DESCRIPTION
This pull request adds a new package to the default system profile. The most important change is the inclusion of the `runelite` package, which will now be available by default for users.

New package added:

* Added `pkgs.runelite` to the list of default packages in `profiles/defaults.nix`, making RuneLite available by default.