### PR TITLE
Initial nixtzner

### DIFF
--- a/hosts/x86_64-linux/nixtzner.nix
+++ b/hosts/x86_64-linux/nixtzner.nix
@@ -1,0 +1,90 @@
+{
+  adminUser,
+  config,
+  lib,
+  ...
+}:
+{
+  publicKey = "";
+
+  imports = [
+    #../../profiles/hardware/usbcore.nix
+    ../../profiles/hardware/intel.nix
+    #../../profiles/admin-user/home-manager.nix
+    ../../profiles/admin-user/user.nix
+    ../../profiles/disk/btrfs-on-luks.nix
+    ../../profiles/k3s.nix
+    #../../profiles/greetd.nix
+    #../../profiles/home-manager.nix
+    #../../profiles/restic-backup.nix
+    ../../profiles/server.nix
+    ../../profiles/state.nix
+    #../../profiles/tailscale.nix
+    ../../profiles/zram.nix
+  ];
+
+  #boot.loader.systemd-boot.memtest86.enable = true;
+
+  boot.loader.systemd-boot.enable = lib.mkForce false;
+  boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
+
+  boot.loader.grub.enable = true;
+  boot.loader.grub.device = "/dev/sdb";
+
+  boot.initrd = {
+    systemd.enable = true;
+  };
+
+  # btrfs.disks = ["/dev/nvme0n1"];
+
+  #services.ratbagd.enable = true;
+
+  #age.secrets = {
+  #  id_ed25519 = {
+  #    file = ../../secrets/id_ed25519.age;
+  #    owner = "${toString adminUser.uid}";
+  #    path = "/home/${adminUser.name}/.ssh/id_ed25519";
+  #  };
+  #};
+
+  boot.initrd.network.ssh = {
+    enable = true;
+    port = 2222;
+    hostKeys = [
+      "/keep/secrets/initrd_ed25519_key"
+    ];
+    authorizedKeys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN5F3BVlkYb6CimwNHkKxMC+FvoLLbhBEPtJEa31BLxq nemko@mba"
+      "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIGWqiT3pihX88HrCvpnnsWANv3RJm5SdMJwZkRHpfHj5AAAABHNzaDo= nemko@nixbox"
+    ];
+  };
+
+  btrfs = {
+    disks = [
+      "/dev/sda"
+      "/dev/sdb"
+    ];
+  };
+
+  boot = {
+    kernelParams = [
+      #"ip=138.201.128.250::138.201.128.193:255.255.255.192:nixtzner::none"
+      "ip=::::::dhcp"
+    ];
+    initrd = {
+      availableKernelModules = [
+        "igb"
+        "nvme"
+        "ahci"
+        "usbhid"
+        "i915"
+        "r8169"
+      ];
+      network = {
+        enable = true;
+        flushBeforeStage2 = true;
+        postCommands = "echo 'cryptsetup-askpass' >> /root/.profile";
+      };
+    };
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./home.nix
     ./host-config.nix
+    ./k3s.nix
     ./services.nix
   ];
 }

--- a/modules/k3s.nix
+++ b/modules/k3s.nix
@@ -1,0 +1,180 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  l = lib // builtins;
+  inherit (l)
+    optional
+    mkOption
+    mkIf
+    mkForce
+    types
+    mapAttrsToList
+    flatten
+    concatStringsSep
+    isList
+    isString
+    isPath
+    isAttrs
+    isBool
+    mapAttrs
+    sort
+    lessThan
+    ;
+  cfg = config.services.k3s;
+  k3sManifestsDir = "/var/lib/rancher/k3s/server/manifests";
+  containerdConfigDir = "/var/lib/rancher/k3s/agent/etc/containerd";
+  getIfaceIp = pkgs.writeShellApplication {
+    name = "get-iface-ip";
+    runtimeInputs = with pkgs; [
+      jq
+      iproute2
+    ];
+    text = ''
+      IFACE=''${1:-}
+      if [ "$IFACE" = "" ]; then
+        echo Please provide the interface to get the ip off of
+        exit 1
+      fi
+      ip -o -4 -family inet -json addr show scope global dev "$IFACE" | jq -r '.[0].addr_info[0].local'
+    '';
+  };
+  settingsToCli =
+    s:
+    let
+      boolToCli = path: value: if value then "--${path}" else "";
+      listToCli = path: value: concatStringsSep " " (map (item: "--${path} ${toString item}") value);
+      attrsToCli =
+        path:
+        mapAttrsToList (
+          k: v:
+          if isBool v then
+            boolToCli path v
+          else if v == null then
+            ""
+          else
+            "--${path} ${k}=${toString v}"
+        );
+      fieldToCli =
+        path: value:
+        if isAttrs value then
+          attrsToCli path value
+        else if isBool value then
+          boolToCli path value
+        else if isList value then
+          listToCli path value
+        else if value == null then
+          ""
+        else
+          "--${path} ${toString value}";
+    in
+    flatten (mapAttrsToList fieldToCli s);
+in
+{
+  options.services.k3s.autoDeploy = mkOption {
+    type = types.attrsOf (types.either types.path (types.attrsOf types.anything));
+    default = { };
+    apply = mapAttrs (
+      name: value:
+      if (isPath value || isString value) then
+        value
+      else
+        pkgs.runCommand "${name}.yaml" { } ''
+          cat<<'EOF'>$out
+          ${builtins.toJSON value}
+          EOF
+        ''
+    );
+  };
+
+  options.services.k3s.after = mkOption {
+    type = types.listOf types.str;
+    default = [ ];
+  };
+
+  options.services.k3s.disable = mkOption {
+    type = types.listOf (
+      types.enum [
+        "coredns"
+        "servicelb"
+        "traefik"
+        "local-storage"
+        "metrics-server"
+      ]
+    );
+    default = [ ];
+  };
+
+  options.services.k3s.settings = mkOption {
+    type = types.attrsOf types.anything;
+    default = { };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = mkForce [ ];
+    services.k3s.extraFlags = concatStringsSep " " (sort lessThan (settingsToCli cfg.settings));
+    systemd.services.k3s =
+      let
+        k3s = pkgs.writeShellApplication {
+          name = "k3s";
+          runtimeInputs = with pkgs; [
+            getIfaceIp
+            gawk
+            envsubst
+          ];
+          text = concatStringsSep " " (
+            [
+              "exec ${cfg.package}/bin/k3s ${cfg.role}"
+            ]
+            ++ (optional cfg.clusterInit "--cluster-init")
+            ++ (optional cfg.disableAgent "--disable-agent")
+            ++ (optional (cfg.serverAddr != "") "--server ${cfg.serverAddr}")
+            ++ (optional (cfg.token != "") "--token ${cfg.token}")
+            ++ (optional (cfg.tokenFile != null) "--token-file ${cfg.tokenFile}")
+            ++ (optional (cfg.configPath != null) "--config ${cfg.configPath}")
+            ++ [ cfg.extraFlags ]
+          );
+        };
+      in
+      {
+        after = [
+          "network-online.service"
+          "firewall.service"
+        ]
+        ++ cfg.after;
+        preStart = ''
+          rm -f ${containerdConfigDir}/config.toml.tmpl
+          ${
+            if cfg.role == "server" then
+              ''
+                mkdir -p ${k3sManifestsDir}
+                ${concatStringsSep "\n" (
+                  mapAttrsToList (
+                    name: path: "${pkgs.envsubst}/bin/envsubst < ${path} > ${k3sManifestsDir}/${name}.yaml"
+                  ) cfg.autoDeploy
+                )}
+                ${concatStringsSep "\n" (
+                  map (manifestName: "touch ${k3sManifestsDir}/${manifestName}.yaml.skip") cfg.disable
+                )}
+              ''
+            else
+              ""
+          }
+        '';
+        serviceConfig.EnvironmentFile = lib.mkForce "/run/nixos/metadata";
+        serviceConfig.ExecStart = lib.mkForce "${k3s}/bin/k3s";
+      };
+    boot.kernelModules = [
+      "br_netfilter"
+      "ip_conntrack"
+      "ip_vs"
+      "ip_vs_rr"
+      "ip_vs_wrr"
+      "ip_vs_sh"
+      "overlay"
+    ];
+  };
+}

--- a/profiles/hardware/intel.nix
+++ b/profiles/hardware/intel.nix
@@ -1,0 +1,4 @@
+{
+  hardware.cpu.intel.updateMicrocode = true;
+  boot.kernelModules = ["kvm-intel"];
+}

--- a/profiles/k3s.nix
+++ b/profiles/k3s.nix
@@ -1,0 +1,5 @@
+{
+  services.k3s = {
+    enable = true;
+  };
+}

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -1,0 +1,53 @@
+{
+  pkgs,
+  inputs,
+  lib,
+  ...
+}:
+let
+  inherit (inputs) nixos-hardware;
+in
+{
+  imports = [
+    "${nixos-hardware}/common/pc/ssd"
+    ./defaults.nix
+  ];
+
+  networking.usePredictableInterfaceNames = false;
+  networking.useDHCP = true;
+
+  environment.systemPackages = [
+    pkgs.wget
+    pkgs.vim
+    pkgs.curl
+    pkgs.man-pages
+    pkgs.cacert
+    pkgs.zip
+    pkgs.unzip
+    pkgs.jq
+    pkgs.git
+    pkgs.fd
+    pkgs.lsof
+    pkgs.fish
+    pkgs.wireguard-tools
+    pkgs.nfs-utils
+    pkgs.iptables
+  ];
+
+  boot.kernel.sysctl = {
+    "fs.inotify.max_user_watches" = 524288;
+    "fs.inotify.max_user_instances" = 8192;
+  };
+
+  services.openssh.enable = true;
+  services.openssh.settings.PasswordAuthentication = false;
+
+  networking.firewall.allowedTCPPorts = [ 22 ];
+
+  services.smartd.enable = true;
+
+  programs.fish.enable = true;
+  security.sudo.wheelNeedsPassword = false;
+
+  machinePurpose = lib.mkForce "server";
+}


### PR DESCRIPTION
This pull request introduces a NixOS host configuration for `nixtzner` with a strong focus on server and Kubernetes (k3s) support, as well as hardware-specific optimizations and improved system defaults. The main changes include the addition of a custom k3s module, new profiles for hardware and server roles, and the integration of these into the host configuration.

**Kubernetes (k3s) integration:**
- Added a custom `k3s.nix` module providing flexible options for k3s deployment, including manifest auto-deployment, service configuration, and kernel module requirements. This is integrated into the system via the new `profiles/k3s.nix` profile and imported in the host and module definitions. [[1]](diffhunk://#diff-678542bf949ad47cfeea513d8bb56656a119792fdd32ca90fa6de99f0dd8001bR1-R180) [[2]](diffhunk://#diff-db6999bcf7c56b83f49c8bf780c70db49c505fe6c8128fff38ba04672033f3f9R1-R5) [[3]](diffhunk://#diff-24cbae53da3e4c7b899685295737b955daa048345f53ef85ab51b07270d7b31eR5) [[4]](diffhunk://#diff-52860aad9c5e3fad058c09b64b0c5cfe9eff5a5ebef29153299e3ab9516e2a54R1-R90)

**Server and hardware profiles:**
- Introduced a `server.nix` profile that sets up common server packages, sysctl parameters, SSH hardening, firewall rules, and disables predictable network interface names for easier management. [[1]](diffhunk://#diff-4b7597e88d349fc878848c090407eecff39e4805ff15975450ac6e71d4c2d8e5R1-R53) [[2]](diffhunk://#diff-52860aad9c5e3fad058c09b64b0c5cfe9eff5a5ebef29153299e3ab9516e2a54R1-R90)
- Added an `intel.nix` hardware profile to enable Intel CPU microcode updates and load the `kvm-intel` kernel module, improving hardware compatibility and virtualization support. [[1]](diffhunk://#diff-4cd38c1d96d1d225fed08638e8599b0d691c8f5afa2a9fcd21c55df9eec5dbaaR1-R4) [[2]](diffhunk://#diff-52860aad9c5e3fad058c09b64b0c5cfe9eff5a5ebef29153299e3ab9516e2a54R1-R90)

**Host configuration for nixtzner:**
- Created the `nixtzner.nix` host configuration, which imports the new and existing profiles, configures boot loaders, sets up Btrfs on multiple disks, enables initrd SSH access, and customizes kernel/initrd/network settings for robust server operation.

These changes lay the groundwork for a robust, reproducible NixOS server setup with integrated Kubernetes support and hardware optimizations.