### PR TITLE
Enable uuid_crypt

### DIFF
--- a/hosts/x86_64-linux/nixtzner.nix
+++ b/hosts/x86_64-linux/nixtzner.nix
@@ -13,6 +13,7 @@
     #../../profiles/admin-user/home-manager.nix
     ../../profiles/admin-user/user.nix
     ../../profiles/disk/btrfs-on-luks.nix
+    ../../profiles/uuid_disk_crypt.nix
     ../../profiles/k3s.nix
     #../../profiles/greetd.nix
     #../../profiles/home-manager.nix

--- a/profiles/uuid_disk_crypt.nix
+++ b/profiles/uuid_disk_crypt.nix
@@ -1,0 +1,6 @@
+{ lib, ... }:
+{
+  boot.initrd.luks.devices = {
+    cryptkey.keyFile = lib.mkDefault "/sys/class/dmi/id/product_uuid";
+  };
+}


### PR DESCRIPTION
This pull request introduces support for unlocking LUKS-encrypted disks using the system's product UUID as a key file. The main changes include adding a new configuration profile and updating the host configuration to include this profile.

LUKS disk encryption improvements:

* Added a new profile, `uuid_disk_crypt.nix`, which configures the system to use `/sys/class/dmi/id/product_uuid` as the key file for unlocking LUKS devices.
* Updated the `nixtzner.nix` host configuration to include the new `uuid_disk_crypt.nix` profile, enabling this functionality on the host.