### PR TITLE
Disable initrd on nixtzner

### DIFF
--- a/hosts/x86_64-linux/nixtzner.nix
+++ b/hosts/x86_64-linux/nixtzner.nix
@@ -32,10 +32,6 @@
   boot.loader.grub.enable = true;
   boot.loader.grub.device = "/dev/sdb";
 
-  boot.initrd = {
-    systemd.enable = true;
-  };
-
   # btrfs.disks = ["/dev/nvme0n1"];
 
   #services.ratbagd.enable = true;
@@ -48,18 +44,6 @@
   #  };
   #};
 
-  boot.initrd.network.ssh = {
-    enable = true;
-    port = 2222;
-    hostKeys = [
-      "/keep/secrets/initrd_ed25519_key"
-    ];
-    authorizedKeys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN5F3BVlkYb6CimwNHkKxMC+FvoLLbhBEPtJEa31BLxq nemko@mba"
-      "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIGWqiT3pihX88HrCvpnnsWANv3RJm5SdMJwZkRHpfHj5AAAABHNzaDo= nemko@nixbox"
-    ];
-  };
-
   btrfs = {
     disks = [
       "/dev/sda"
@@ -67,25 +51,4 @@
     ];
   };
 
-  boot = {
-    kernelParams = [
-      #"ip=138.201.128.250::138.201.128.193:255.255.255.192:nixtzner::none"
-      "ip=::::::dhcp"
-    ];
-    initrd = {
-      availableKernelModules = [
-        "igb"
-        "nvme"
-        "ahci"
-        "usbhid"
-        "i915"
-        "r8169"
-      ];
-      network = {
-        enable = true;
-        flushBeforeStage2 = true;
-        postCommands = "echo 'cryptsetup-askpass' >> /root/.profile";
-      };
-    };
-  };
 }


### PR DESCRIPTION
This pull request cleans up the `hosts/x86_64-linux/nixtzner.nix` configuration by removing several boot and initrd-related settings, particularly those related to systemd in the initrd, SSH access during initrd, and custom kernel parameters. These changes simplify the system's boot configuration and remove network and SSH access during the early boot stage.

Boot and initrd configuration cleanup:

* Removed enabling of `systemd` in the `boot.initrd` section, simplifying the initrd configuration.
* Removed the entire `boot.initrd.network.ssh` block, disabling SSH access to the initrd environment, including custom port, host keys, and authorized keys.
* Removed custom kernel parameters and related `boot.initrd.network` settings, including available kernel modules and network post-commands, reducing complexity and potential surface area for misconfiguration.