### PR TITLE
Change grub device to sda on nixtzner

### DIFF
--- a/hosts/x86_64-linux/nixtzner.nix
+++ b/hosts/x86_64-linux/nixtzner.nix
@@ -30,7 +30,7 @@
   boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
 
   boot.loader.grub.enable = true;
-  boot.loader.grub.device = "/dev/sdb";
+  boot.loader.grub.device = "/dev/sda";
 
   # btrfs.disks = ["/dev/nvme0n1"];
 


### PR DESCRIPTION
This pull request makes a small but important change to the GRUB bootloader configuration in the `hosts/x86_64-linux/nixtzner.nix` file. The GRUB bootloader's target device has been switched from `/dev/sdb` to `/dev/sda`, which will affect which disk the system uses to install and boot from GRUB.

* Changed the GRUB bootloader device from `/dev/sdb` to `/dev/sda` in `hosts/x86_64-linux/nixtzner.nix`