### PR TITLE
nvim no colemak binds, vmware disabled, runelite state

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -57,6 +57,7 @@
         ".config/warcraftlogs"
         ".factorio"
         ".gnupg"
+        ".runelite"
         ".local/share/Steam"
         ".local/share/TelegramDesktop"
         ".local/share/atuin"

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -49,7 +49,7 @@
   virtualisation.podman.enable = false;
   virtualisation.podman.dockerCompat = false;
 
-  virtualisation.vmware.host.enable = true;
+  virtualisation.vmware.host.enable = false;
 
   virtualisation.libvirtd = {
     enable = false;

--- a/users/profiles/neovim/default.nix
+++ b/users/profiles/neovim/default.nix
@@ -45,7 +45,6 @@ in
       require "plugins"
       require "keymaps"
       require "commands"
-      require "colemak"
     '';
     plugins = with pkgs.vimPlugins; [
       CopilotChat-nvim


### PR DESCRIPTION
This pull request introduces several configuration updates, mainly focusing on virtual machine support, user profile settings, and application state management. The most notable changes are the disabling of VMware host virtualization, the addition of a new application state directory, and the removal of a specific Neovim configuration.

**Virtualization configuration:**
* Disabled VMware host virtualization by setting `virtualisation.vmware.host.enable` to `false` in `workstation.nix`. This means VMware will no longer be enabled by default on workstations.

**State management:**
* Added `.runelite` to the list of directories managed in `state.nix`, ensuring its state is preserved or synchronized as part of user profile management.

**Neovim user profile:**
* Removed the requirement for the `colemak` module from the Neovim configuration, likely simplifying or changing the default keymap setup.