### PR TITLE
K3s bye flannel, hello cilium

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,6 +103,19 @@
         "type": "github"
       }
     },
+    "cilium-chart": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755265843,
+        "narHash": "sha256-baUV4ysp1UP3fAdwrPVqXj8PzSNR3UI4YRZworHG71U=",
+        "type": "tarball",
+        "url": "https://github.com/cilium/charts/raw/refs/heads/master/cilium-1.18.1.tgz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/cilium/charts/raw/refs/heads/master/cilium-1.18.1.tgz"
+      }
+    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -890,11 +903,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1756416356,
-        "narHash": "sha256-xcqREhXocGZPbDsvjD7ncDz8++jfX5ZwpGc0maiD9CY=",
+        "lastModified": 1756451161,
+        "narHash": "sha256-4ZMY6S07CW/OIA1ZwCZRreiOMRC5Zqzlr8G1B3fpVrU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e4de97a152b367ba92ee590ff67fee4f33c46d92",
+        "rev": "23434fd75614ec677013b3554dbb0481c11dd6ab",
         "type": "github"
       },
       "original": {
@@ -955,6 +968,7 @@
         "age-plugin-yubikey": "age-plugin-yubikey",
         "agenix": "agenix",
         "cachix": "cachix",
+        "cilium-chart": "cilium-chart",
         "devenv": "devenv",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts_2",

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,8 @@
       flake-compat.follows = "flake-compat";
       nixpkgs.follows = "nixpkgs";
     };
+    cilium-chart.url = "https://github.com/cilium/charts/raw/refs/heads/master/cilium-1.18.1.tgz";
+    cilium-chart.flake = false;
     #crane.url = "github:ipetkov/crane";
     devenv.inputs.flake-compat.follows = "flake-compat";
     devenv.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake/hosts.nix
+++ b/flake/hosts.nix
@@ -79,6 +79,7 @@ let
             hostName = name;
             tailnet = "tail754457";
             inherit adminUser;
+            inherit self;
             hostConfigurations = mapAttrs' (name: conf: {
               inherit name;
               value = conf.config;

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -40,6 +40,7 @@
               nushell
               statix
               deadnix
+              cachix
             ];
             text = ''
               just -f ${../Justfile} -d "$(pwd)" "$@"

--- a/profiles/k3s-agent.nix
+++ b/profiles/k3s-agent.nix
@@ -5,15 +5,5 @@
   services.k3s = {
     enable = true;
     role = "agent";
-    after = [
-      "tailscale-auth.service"
-      "tailscaled.service"
-    ];
-
-    settings = {
-      node-ip = "\"$(get-iface-ip tailscale0)\"";
-      flannel-iface = "tailscale0";
-      token-file = "/run/agenix/k3s-token";
-    };
   };
 }

--- a/profiles/k3s-master.nix
+++ b/profiles/k3s-master.nix
@@ -1,9 +1,17 @@
 {
   pkgs,
+  config,
+  inputs,
   tailnet,
   hostName,
   ...
 }:
+let
+  inherit (config.services.k3s) settings;
+  cluster-cidr = "10.244.0.0/16";
+  service-cidr = "10.96.0.0/12";
+  cluster-dns = "10.96.0.10";
+in
 {
   imports = [
     ./k3s.nix
@@ -11,21 +19,21 @@
   services.k3s = {
     enable = true;
     role = "server";
-    after = [
-      "tailscale-auth.service"
-      "tailscaled.service"
-    ];
-
     settings = {
-      token-file = "/run/agenix/k3s-token";
-      cluster-cidr = "10.244.0.0/16";
-      service-cidr = "10.96.0.0/12";
-      cluster-dns = "10.96.0.10";
+      disable = [
+        "servicelb"
+        "traefik"
+        "metrics-server"
+      ];
+      flannel-backend = "none";
+      disable-network-policy = true;
+      disable-kube-proxy = true;
+      disable-cloud-controller = true;
       node-name = hostName;
       advertise-address = "\"$(get-iface-ip tailscale0)\"";
+      inherit cluster-cidr service-cidr cluster-dns;
       kube-controller-manager-arg.node-cidr-mask-size = 24;
       node-label."svccontroller.k3s.cattle.io/enablelb" = "true";
-      node-label.hostname = hostName;
       secrets-encryption = true;
       tls-san = [
         hostName
@@ -33,8 +41,31 @@
       ];
     };
 
-    #autoDeploy = {
-    #  kured = "${pkgs.kured-yaml}/kured.yaml";
-    #};
+    autoDeploy =
+      let
+        cilium = pkgs.runCommand "helm-template" { allowSubstitution = false; } ''
+          mkdir -p $out
+          ${pkgs.kubernetes-helm}/bin/helm template cilium ${inputs.cilium-chart} \
+            --namespace kube-system \
+            --set kubeProxyReplacement=true \
+            --set socketLB.hostNamespaceOnly=true \
+            --set cni.exclusive=false \
+            --set k8sServiceHost="100.123.142.40" \
+            --set k8sServicePort=6443 \
+            --set enableExternalIPs=true \
+            --set enableHostPort=true \
+            --set enableNodePort=true \
+            --set ipam.operator.clusterPoolIPv4PodCIDRList=${settings.cluster-cidr} \
+            --set ingressController.enabled=true \
+            --set ingressController.loadbalancerMode=dedicated \
+            --set encryption.enabled=false \
+            --set encryption.type=wireguard \
+            --set encryption.nodeEncryption=true > "$out"/cilium.yaml
+        '';
+      in
+      {
+        #kured = "${pkgs.kured-yaml}/kured.yaml";
+        cilium = "${cilium}/cilium.yaml";
+      };
   };
 }

--- a/profiles/k3s.nix
+++ b/profiles/k3s.nix
@@ -8,6 +8,16 @@
     ../profiles/tailscale.nix
   ];
 
+  networking.firewall = {
+    trustedInterfaces = [
+      "lo"
+      "cilium_host"
+      "cilium_net"
+      "cilium_vxlan"
+      "lxc+"
+    ];
+  };
+
   systemd.services.metadata =
     let
       cloudInitScript = pkgs.writeShellScript "cloud-init" ''
@@ -24,8 +34,6 @@
       description = "Metadata Service";
       after = [ "network.target" ];
       before = [
-        "tailscale-auth.service"
-        "tailscaled.service"
         "k3s.service"
       ];
       wantedBy = [ "multi-user.target" ];
@@ -39,24 +47,18 @@
     enable = true;
     after = [
       "tailscale-auth.service"
-      "tailscaled.service"
-    ];
-    disable = [
-      "servicelb"
-      "traefik"
-      "metrics-server"
+      "metadata.service"
     ];
     settings = {
       token-file = "/run/agenix/k3s-token";
-      flannel-iface = "tailscale0";
-      #flannel-iface = "enp14s0";
       node-name = hostName;
       server = "https://nixbox.tail754457.ts.net:6443";
       node-ip = "\"$(get-iface-ip tailscale0)\"";
-      node-external-ip = "\"$(get-iface-ip eth0)\"";
+      node-external-ip = "\"$(get-default-route-ip)\"";
       node-label."topology.kubernetes.io/region" = "\"$REGION\"";
       node-label."topology.kubernetes.io/zone" = "\"$ZONE\"";
       node-label."hostname" = hostName;
+      kubelet-arg = "register-with-taints=node.cilium.io/agent-not-ready:NoExecute";
     };
   };
 
@@ -69,13 +71,6 @@
     args.auth-key = "file:/var/run/agenix/ts";
   };
 
-  networking.firewall.trustedInterfaces = [
-    "cni+"
-    "flannel.1"
-    "calico+"
-    "cilium+"
-    "lxc+"
-  ];
   environment.persistence."/keep" = {
     directories = [
       "/etc/cni"
@@ -92,13 +87,4 @@
   #   device = "storage01:/volume1/persistentvolume";
   #   fsType = "nfs";
   # };
-
-  fileSystems."/sys/fs/bpf" = {
-    device = "bpffs";
-    fsType = "bpf";
-    options = [
-      "rw"
-      "relatime"
-    ];
-  };
 }

--- a/profiles/tailscale.nix
+++ b/profiles/tailscale.nix
@@ -5,4 +5,5 @@
   };
 
   networking.firewall.trustedInterfaces = [ "tailscale0" ];
+  networking.firewall.checkReversePath = "loose";
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the Kubernetes (`k3s`) deployment setup, focusing on enhanced Cilium integration, improved networking/firewall configuration, and more flexible manifest templating. The changes streamline the deployment process, improve security, and lay groundwork for more robust cluster management.

**K3s and Cilium Integration:**
- Added support for deploying Cilium as the primary CNI by templating and auto-deploying the Cilium Helm chart, including new flake input for the chart and an updated `autoDeploy` mechanism for the k3s master profile. [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R31-R32) [[2]](diffhunk://#diff-f55d2351cb1059c134959cad3f0e8cf54b741b1cf99f15c4a7d0f44ab35d7ac7R3-R69)

**Networking and Firewall Enhancements:**
- Updated firewall configuration to explicitly trust Cilium-related interfaces and set `checkReversePath` to `"loose"` for Tailscale, improving compatibility and security. [[1]](diffhunk://#diff-db6999bcf7c56b83f49c8bf780c70db49c505fe6c8128fff38ba04672033f3f9R11-R20) [[2]](diffhunk://#diff-b6e44f4d84ca72074e1dd3425c72551e59f4b9dceec0f3bde6257b7fb0b58c0eR8)
- Refined how network interfaces are determined for node IPs by introducing new helper scripts (`get-default-route-ip`, `get-iface-with-mac`) and using them in node configuration, ensuring correct external IP assignment for nodes. [[1]](diffhunk://#diff-678542bf949ad47cfeea513d8bb56656a119792fdd32ca90fa6de99f0dd8001bR45-R70) [[2]](diffhunk://#diff-db6999bcf7c56b83f49c8bf780c70db49c505fe6c8128fff38ba04672033f3f9L42-R61)

**Manifest Templating and Automation:**
- Enhanced manifest templating by switching from `envsubst` to `gettext` and allowing explicit control over which environment variables are substituted, reducing risk of accidental replacements. [[1]](diffhunk://#diff-678542bf949ad47cfeea513d8bb56656a119792fdd32ca90fa6de99f0dd8001bR103-R112) [[2]](diffhunk://#diff-678542bf949ad47cfeea513d8bb56656a119792fdd32ca90fa6de99f0dd8001bL156-R196)
- Added `allowedReplacementVars` option to restrict which variables are substituted in manifests, improving security and predictability.

**General Improvements and Cleanup:**
- Cleaned up and simplified k3s agent/master profiles by removing redundant dependencies and settings, and updating node taints and labels for better Cilium compatibility. [[1]](diffhunk://#diff-d58777e87b47af5dee0960a3200b9136e22192d8e70c70e989f02146bcbc92c9L8-L17) [[2]](diffhunk://#diff-f55d2351cb1059c134959cad3f0e8cf54b741b1cf99f15c4a7d0f44ab35d7ac7R3-R69)
- Removed obsolete or redundant filesystem and firewall definitions, reflecting the move to Cilium and updated networking model. [[1]](diffhunk://#diff-db6999bcf7c56b83f49c8bf780c70db49c505fe6c8128fff38ba04672033f3f9L72-L78) [[2]](diffhunk://#diff-db6999bcf7c56b83f49c8bf780c70db49c505fe6c8128fff38ba04672033f3f9L95-L103)

**Tooling and Package Updates:**
- Added `cachix` to the development shell packages for improved Nix caching support.
- Minor internal improvements, such as passing `self` in host configuration and updating runtime inputs for shell scripts. [[1]](diffhunk://#diff-039b8606f52e81ca24829f97b24bf15c642420f7ca30a28a4de3a406a8d3ae44R82) [[2]](diffhunk://#diff-678542bf949ad47cfeea513d8bb56656a119792fdd32ca90fa6de99f0dd8001bR162-R165)