### PR TITLE
Add SSH key for user nemko

### DIFF
--- a/profiles/admin-user/user.nix
+++ b/profiles/admin-user/user.nix
@@ -14,6 +14,7 @@
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN5F3BVlkYb6CimwNHkKxMC+FvoLLbhBEPtJEa31BLxq"
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOu2XRGagRGIG7uCvcwhsDkB4YtoXqMIcKhXFK1pW8Nr"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFh4MHoAx2/HhQf6mGnb3HJI8DDJtNkC84dhaNPnHZfE"
       ];
       extraGroups = [
         "wheel"


### PR DESCRIPTION
This pull request makes a small update to the SSH authorized keys for the admin user by adding a new public key. This allows an additional user or device to access the system via SSH.

* Added a new SSH public key to the `openssh.authorizedKeys.keys` array in `profiles/admin-user/user.nix`.