### PR TITLE
Don't set cilium ingressController

### DIFF
--- a/profiles/k3s-master.nix
+++ b/profiles/k3s-master.nix
@@ -56,8 +56,6 @@ in
             --set enableHostPort=true \
             --set enableNodePort=true \
             --set ipam.operator.clusterPoolIPv4PodCIDRList=${settings.cluster-cidr} \
-            --set ingressController.enabled=true \
-            --set ingressController.loadbalancerMode=dedicated \
             --set encryption.enabled=false \
             --set encryption.type=wireguard \
             --set encryption.nodeEncryption=true > "$out"/cilium.yaml


### PR DESCRIPTION
This pull request makes a small change to the `profiles/k3s-master.nix` file by removing the configuration that enabled and set the mode for the ingress controller in the Cilium setup. This means the ingress controller will no longer be enabled by default in this profile.