### PR TITLE
Hyprland monitor negative value DP-4

### DIFF
--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -143,9 +143,11 @@ in
 
   wayland.windowManager.hyprland.settings = {
     monitor = [
-      "DP-4, preferred, 0x0, 1, transform, 1"
-      "DP-3, preferred, 1440x0, 1.33"
-      "DP-5, preferred, 4327x0, 1, transform, 3"
+      "DP-3, preferred, 0x0, 1.33"
+      "DP-4, preferred, -1440x0, 1, transform, 1"
+      #"DP-4, disable"
+      "DP-5, preferred, 2880x0, 1, transform, 3"
+      #"DP-5, disable"
     ];
     "$mod" = "SUPER";
     bind = [


### PR DESCRIPTION
This pull request updates the monitor configuration in the `hyprland.nix` user profile. The changes adjust the arrangement and scaling of monitors, and add commented-out options to disable specific monitors.

Monitor configuration updates:

* Reordered monitors and changed their positions: `DP-3` is now the primary monitor at position `0x0` with a scaling factor of `1.33`, `DP-4` is moved to `-1440x0` with a transform, and `DP-5` is set to `2880x0` with a transform.
* Added commented-out lines to optionally disable `DP-4` and `DP-5` monitors for easier toggling.