### PR TITLE
Initial framework desktop

### DIFF
--- a/hosts/x86_64-linux/framenix.nix
+++ b/hosts/x86_64-linux/framenix.nix
@@ -1,0 +1,74 @@
+{
+  adminUser,
+  lib,
+  config,
+  ...
+}:
+{
+  publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILWkKCvGPLYGiz8bY0cHI5INItAT8t6cQcfurKLd7nSz";
+
+  imports = [
+    ../../profiles/hardware/usbcore.nix
+    ../../profiles/hardware/amd.nix
+    ../../profiles/admin-user/home-manager.nix
+    ../../profiles/admin-user/user.nix
+    ../../profiles/disk/btrfs-on-luks.nix
+    ../../profiles/uuid_disk_crypt.nix 
+    ../../profiles/desktop.nix
+    ../../profiles/greetd.nix
+    ../../profiles/home-manager.nix
+    #../../profiles/restic-backup.nix
+    ../../profiles/state.nix
+    ../../profiles/tailscale.nix
+    ../../profiles/zram.nix
+    ../../profiles/k3s-master.nix
+  ];
+
+  boot.loader.systemd-boot.memtest86.enable = true;
+
+  boot.initrd = {
+    systemd.enable = true;
+  };
+
+  # btrfs.disks = ["/dev/nvme0n1"];
+
+  services.ratbagd.enable = true;
+
+  #age.secrets = {
+  #  id_ed25519 = {
+  #    file = ../../secrets/id_ed25519.age;
+  #    owner = "${toString adminUser.uid}";
+  #    path = "/home/${adminUser.name}/.ssh/id_ed25519";
+  #  };
+  #};
+
+  programs.steam.enable = true;
+  services.flatpak.enable = true;
+
+  home-manager = {
+    users.${adminUser.name} = {
+      imports = [ ../../users/profiles/workstation.nix ];
+      #      programs.git.extraConfig.user.signingKey = "key::sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIH8FItRsdPvpg8mTCF7gsKQJ4ABaOCE8a6PzamumRWe3AAAABHNzaDo=";
+      #      programs.jujutsu.settings.signing = {
+      #        sign-all = true;
+      #        backend = "ssh";
+      #        key = config.age.secrets.id_ed25519.path;
+      #      };
+    };
+  };
+
+  age.secrets = {
+    k3s-token = {
+      file = ../../secrets/k3s/token.age;
+    };
+    ts = {
+      file = ../../secrets/ts.age;
+      owner = "1100";
+    };
+  };
+
+  services.k3s.settings = {
+    server = lib.mkForce "";
+    node-external-ip = lib.mkForce "\"$(get-iface-ip enp14s0)\"";
+  };
+}


### PR DESCRIPTION
This pull request introduces a new NixOS host configuration for `framenix` in the `hosts/x86_64-linux` directory. The configuration sets up a desktop environment with several hardware and user profiles, enables key services and programs, and manages secrets for secure operations. The most important changes are grouped below:

**System Configuration and Imports:**
* Adds a new host configuration file `framenix.nix` with imports for hardware, disk, user, and desktop profiles, including support for AMD hardware, Btrfs on LUKS, and k3s master setup.
* Enables systemd-boot memtest86, systemd-based initrd, and zram for improved boot and memory management.

**Service and Program Enablement:**
* Activates essential services and programs such as `ratbagd` (mouse configuration), `steam`, `flatpak`, and `tailscale` for gaming, application management, and networking.

**User and Home Manager Configuration:**
* Configures `home-manager` for the admin user, importing workstation-specific settings and allowing further customization.

**Secret Management:**
* Defines `age.secrets` for securely managing sensitive files like `k3s-token` and `ts`, specifying file locations and ownership.

**K3s Cluster