### PR TITLE
Framenix no ratbagd+k3s master

### DIFF
--- a/hosts/x86_64-linux/framenix.nix
+++ b/hosts/x86_64-linux/framenix.nix
@@ -21,7 +21,6 @@
     ../../profiles/state.nix
     ../../profiles/tailscale.nix
     ../../profiles/zram.nix
-    ../../profiles/k3s-master.nix
   ];
 
   boot.loader.systemd-boot.memtest86.enable = true;
@@ -30,9 +29,6 @@
     systemd.enable = true;
   };
 
-  # btrfs.disks = ["/dev/nvme0n1"];
-
-  services.ratbagd.enable = true;
 
   #age.secrets = {
   #  id_ed25519 = {


### PR DESCRIPTION
This pull request makes a few small changes to the `framenix.nix` host configuration. The main updates involve removing the inclusion of the `k3s-master` profile and disabling the `ratbagd` service.

Most important changes:

Configuration cleanup:
* Removed the `../../profiles/k3s-master.nix` profile from the list of imported profiles, likely indicating this host is no longer intended to act as a k3s master.
* Disabled the `services.ratbagd.enable` option, so the `ratbagd` service will no longer be started on this host.