### PR TITLE
Framenix k3s agent

### DIFF
--- a/hosts/x86_64-linux/framenix.nix
+++ b/hosts/x86_64-linux/framenix.nix
@@ -17,6 +17,7 @@
     ../../profiles/desktop.nix
     ../../profiles/greetd.nix
     ../../profiles/home-manager.nix
+    ../../profiles/k3s-agent.nix
     #../../profiles/restic-backup.nix
     ../../profiles/state.nix
     ../../profiles/tailscale.nix


### PR DESCRIPTION
This pull request makes a small update to the system configuration by adding a new profile for a k3s agent.

- Added the `../../profiles/k3s-agent.nix` profile to the `framenix.nix` host configuration, enabling k3s agent functionality.