### PR TITLE
Enable LM Studio

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -36,6 +36,7 @@
         ".cache/rbw"
         ".cache/zellij"
         ".cargo"
+        ".config/LM Studio"
         ".config/Signal"
         ".config/WowUpCf"
         ".config/beekeeper-studio"
@@ -57,6 +58,7 @@
         ".config/warcraftlogs"
         ".factorio"
         ".gnupg"
+        ".lmstudio"
         ".runelite"
         ".local/share/Steam"
         ".local/share/TelegramDesktop"
@@ -93,6 +95,7 @@
         ".cockroachsql_history"
         ".config/nushell/history.txt"
         ".kube/config"
+        ".lmstudio-home-pointer"
       ];
     };
   };

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -33,6 +33,7 @@ in
     vesktop
     nixfmt-rfc-style
     libsecret
+    lmstudio
   ];
 
   xdg.configFile."wpaperd/wallpaper.toml".source = pkgs.writeText "wallpaper.toml" ''


### PR DESCRIPTION
This pull request adds support for LM Studio to the workstation profile and updates the persisted state configuration to include LM Studio-related directories and files. These changes ensure LM Studio is installed and its configuration and state are properly managed.

**LM Studio integration:**

* Added `lmstudio` to the list of packages installed in the workstation profile (`users/profiles/workstation.nix`).

**State management updates:**

* Added `.config/LM Studio`, `.lmstudio`, and `.lmstudio-home-pointer` to the list of persisted directories and files in the state configuration (`profiles/state.nix`). [[1]](diffhunk://#diff-c5fb2e5a58c45374ca009e2bc785dd783bc7a698c893fdfb4afc2496c16c6603R39) [[2]](diffhunk://#diff-c5fb2e5a58c45374ca009e2bc785dd783bc7a698c893fdfb4afc2496c16c6603R61) [[3]](diffhunk://#diff-c5fb2e5a58c45374ca009e2bc785dd783bc7a698c893fdfb4afc2496c16c6603R98)