### PR TITLE
chore: update stateVersion 25.05

### DIFF
--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -130,7 +130,7 @@ in
 
   users.mutableUsers = false;
 
-  system.stateVersion = "24.05";
+  system.stateVersion = "25.05";
 
   system.activationScripts.agenixNewGeneration = mkIf (hasSecrets && hasState) {
     deps = [ "persist-files" ];

--- a/users/profiles/default.nix
+++ b/users/profiles/default.nix
@@ -64,5 +64,5 @@
     Install.WantedBy = [ "timers.target" ];
   };
 
-  home.stateVersion = "21.05";
+  home.stateVersion = "25.05";
 }


### PR DESCRIPTION
This pull request updates the system and home state versions to the latest available releases. These changes ensure that both the system and user profiles are aligned with the most recent NixOS standards and features.

Version updates:

* Updated `system.stateVersion` from `"24.05"` to `"25.05"` in `profiles/defaults.nix`, ensuring the system uses the latest NixOS release.
* Updated `home.stateVersion` from `"21.05"` to `"25.05"` in `users/profiles/default.nix`, bringing the user profile configuration up to date.