### PR TITLE
feat: ssh misc fixes

### DIFF
--- a/users/profiles/ssh.nix
+++ b/users/profiles/ssh.nix
@@ -1,21 +1,32 @@
 {
   programs.ssh = {
     enable = true;
-    forwardAgent = false;
-    serverAliveInterval = 60;
-    controlMaster = "auto";
-    controlPersist = "30m";
+    enableDefaultConfig = false;
+
     matchBlocks = {
-      "github github.com" = {
+      "*" = {
+        controlPersist = "30m";
+        controlMaster = "auto";
+        controlPath = "~/.ssh/master-%r@%n:%p";
+        serverAliveInterval = 60;
+        serverAliveCountMax = 3;
+        hashKnownHosts = false;
+        forwardAgent = true;
+        addKeysToAgent = "no";
+        compression = false;
+    };
+    "github github.com" = {
         hostname = "github.com";
         user = "git";
         forwardAgent = false;
         extraOptions = {
           preferredAuthentications = "publickey";
+          controlMaster = "no";
+          controlPath = "none";
         };
       };
-      "nicolina" = {
-        user = "blazed";
+      "framenix" = {
+        user = "nemko";
         forwardAgent = true;
       };
     };


### PR DESCRIPTION
This pull request updates the SSH configuration in `users/profiles/ssh.nix` to provide more explicit and granular control over SSH settings, primarily by disabling default SSH config generation and introducing custom match blocks for different hosts.

**General SSH configuration changes:**

* Disabled the default SSH config generation by setting `enableDefaultConfig = false`, allowing for full customization of SSH settings.
* Moved several global SSH options (such as `controlMaster`, `controlPersist`, `serverAliveInterval`, etc.) into a wildcard (`"*"`) match block for consistent application to all hosts, and added new options like `serverAliveCountMax`, `hashKnownHosts`, `addKeysToAgent`, and `compression`.

**Host-specific SSH configuration changes:**

* Updated the `github github.com` match block to explicitly disable connection multiplexing (`controlMaster = "no"`, `controlPath = "none"`) and set preferred authentication to `publickey`.
* Replaced the `nicolina` match block with a new `framenix` block, changing the user from `blazed` to `nemko` and enabling agent forwarding for this host.