### PR TITLE
bunch of renamed stuff

### DIFF
--- a/profiles/greetd.nix
+++ b/profiles/greetd.nix
@@ -109,7 +109,7 @@ let
         pkgs.bashInteractive
         pkgs.nushell
         pkgs.systemd
-        pkgs.greetd.tuigreet
+        pkgs.tuigreet
       ];
       text = ''
         tuigreet --sessions ${sessionDir} --time -r --remember-session --power-shutdown 'systemctl poweroff' --power-reboot 'systemctl reboot' --cmd ${default}

--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -325,7 +325,7 @@ in
       "[workspace 2 silent] ${pkgs.btop}/bin/btop"
       "[workspace 2 silent] ${pkgs.firefox}/bin/firefox"
       "[workspace 4 silent] ${pkgs.signal-desktop}/bin/signal-desktop"
-      "[workspace 4 silent] ${pkgs.tdesktop}/bin/Telegram"
+      "[workspace 4 silent] ${pkgs.telegram-desktop}/bin/Telegram"
       "[workspace 4 silent] ${pkgs.spotify}/bin/spotify"
       "[workspace 5 silent] ${pkgs.steam}/bin/steam"
       "[workspace 5 silent] ${pkgs.lutris}/bin/lutris"

--- a/users/profiles/neovim/default.nix
+++ b/users/profiles/neovim/default.nix
@@ -19,7 +19,7 @@ in
     extraPackages = with pkgs; [
       actionlint
       docker-compose-language-service
-      dockerfile-language-server-nodejs
+      dockerfile-language-server
       eslint_d
       gofumpt
       gopls

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -25,7 +25,7 @@ in
     scrot
     signal-desktop
     spotify
-    tdesktop # # Telegram
+    telegram-desktop
     vulkan-loader
     wl-clipboard
     wl-clipboard-x11


### PR DESCRIPTION
This pull request updates several package references across multiple Nix profile files to use their canonical or preferred package names. These changes help improve consistency and compatibility with upstream package definitions.

**Package naming and reference updates:**

* Replaced `pkgs.greetd.tuigreet` with `pkgs.tuigreet` in `profiles/greetd.nix` to use the direct package reference.
* Updated `pkgs.tdesktop` to `pkgs.telegram-desktop` in both `users/profiles/hyprland.nix` and `users/profiles/workstation.nix` for Telegram, ensuring the correct package is used. [[1]](diffhunk://#diff-a7299bdaca443eb29bdd665691a5b375c5761479895484b8cc628a463860726aL328-R328) [[2]](diffhunk://#diff-50e5a3621d610ec5dd15b2b918f7dae8d1c0c50ff9c4a051a4ef5de5932ce4fcL28-R28)
* Changed `dockerfile-language-server-nodejs` to `dockerfile-language-server` in `users/profiles/neovim/default.nix` to use the standard package name.