### PR TITLE
fix git deprecated stuff

### DIFF
--- a/profiles/admin-user/home-manager.nix
+++ b/profiles/admin-user/home-manager.nix
@@ -6,7 +6,7 @@
       inherit (adminUser) userinfo;
       programs = {
         git = {
-          extraConfig = {
+          settings = {
             #gpg.format = "ssh";
             #commit.gpgSign = true;
             tag.forceSignAnnotated = true;

--- a/users/profiles/git.nix
+++ b/users/profiles/git.nix
@@ -2,18 +2,14 @@
 {
   programs.git = {
     enable = true;
-    delta = {
-      enable = true;
-      options.features = "decorations side-by-side line-numbers";
-    };
     # TODO
-    userName = "tabasco0322";
-    userEmail = "example@example.com";
-    aliases = {
-      co = "checkout";
-      cob = "checkout -b";
-    };
-    extraConfig = {
+    settings = {
+      user.name = "tabasco0322";
+      user.email = "example@example.com";
+      aliases = {
+        co = "checkout";
+        cob = "checkout -b";
+      };
       core = {
         quotepath = false;
         editor = "nvim";
@@ -48,6 +44,13 @@
     ignores = [
       ".nvimlog" # TODO(blazed): find out why this is needed?
     ];
+  };
+
+  programs.delta = {
+    enable = true;
+    options = {
+      features = "decorations side-by-side line-numbers";
+    };
   };
 
   programs.gh = {


### PR DESCRIPTION
This pull request refactors how git and delta configurations are managed in user profiles, improving clarity and maintainability. The main changes involve moving git user settings into the `settings` attribute, updating delta configuration, and aligning configuration structures across files.

**Git configuration refactor:**

* Moved git user name and email settings from top-level attributes (`userName`, `userEmail`) to the `settings` attribute using `user.name` and `user.email` in `users/profiles/git.nix`.
* Replaced the use of `extraConfig` with `settings` for git configuration in both `profiles/admin-user/home-manager.nix` and `users/profiles/git.nix` to standardize configuration structure [[1]](diffhunk://#diff-2e1fff6c20b08001efbdcd5e3a0c1bcbcdf605880f5e012ef408179fcca68f90L9-R9) [[2]](diffhunk://#diff-f53817832d9bdcdcbbed2381cb56c5e3a23d63cde111b46f17e35de774a82880L5-L16).

**Delta configuration update:**

* Relocated delta configuration from within the git block to a separate top-level `programs.delta` block, enabling delta independently and specifying its options in `users/profiles/git.nix`.

These changes make the configuration more modular and easier to manage, especially as the setup grows.