### PR TITLE
wallpaper delete

### DIFF
--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -202,8 +202,11 @@ in
       force_zero_scaling = true;
     };
 
-    misc.disable_hyprland_logo = true;
-    misc.disable_splash_rendering = true;
+    misc = {
+      disable_hyprland_logo = true;
+      disable_splash_rendering = true;
+      background_color = "0x000000";
+    };
 
     group = {
       groupbar = {
@@ -319,7 +322,6 @@ in
     ];
 
     exec-once = [
-      "${pkgs.wpaperd}/bin/wpaperd"
       "${pkgs.hyprland}/bin/hyprctl setcursor ${xcursor_theme} 24"
       "${pkgs.polkit_gnome.out}/libexec/polkit-gnome-authentication-agent-1"
       "[workspace 2 silent] ${pkgs.btop}/bin/btop"

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -36,17 +36,6 @@ in
     lmstudio
   ];
 
-  xdg.configFile."wpaperd/wallpaper.toml".source = pkgs.writeText "wallpaper.toml" ''
-    [default]
-    path = "~/Pictures/wallpapers"
-    duration = "30m"
-    sorting = "random"
-    apply-shadow = false
-
-    [any]
-    group = 1
-  '';
-
   xdg.configFile."mimeapps.list".force = true;
   xdg.mime.enable = true;
   xdg.mimeApps = {
@@ -74,9 +63,6 @@ in
       "application/x-exension-xht" = "firefox.desktop";
     };
   };
-
-  home.file."Pictures/wallpapers/default-background.jpg".source =
-    "${pkgs.adapta-backgrounds}/share/backgrounds/adapta/tri-fadeno.jpg";
 
   base16-theme.enable = true;
 


### PR DESCRIPTION
This pull request makes several changes to the Hyprland and workstation user profiles, primarily focused on simplifying wallpaper configuration and improving Hyprland appearance settings. The most important updates include refactoring how miscellaneous Hyprland settings are defined, removing wallpaper-related configuration and commands, and ensuring a cleaner startup process.

**Hyprland appearance and configuration:**

* Changed the way miscellaneous Hyprland settings are defined by grouping them into a single `misc` attribute set and added `background_color = "0x000000"` for a black background.

**Wallpaper configuration cleanup:**

* Removed the wallpaper configuration file `wpaperd/wallpaper.toml` from the workstation profile, eliminating custom wallpaper setup.
* Removed the default wallpaper image assignment for `Pictures/wallpapers/default-background.jpg` in the workstation profile.
* Removed the `wpaperd` wallpaper daemon from the Hyprland `exec-once` startup commands, streamlining the session startup.