### PR TITLE
temp fix for slow ssh

### DIFF
--- a/users/profiles/ssh.nix
+++ b/users/profiles/ssh.nix
@@ -1,6 +1,12 @@
 {
+  pkgs,
+  ...
+}:
+{
   programs.ssh = {
     enable = true;
+    # temp fix since 10.1p1 was super slow, remember to delete pkgs import
+    package = pkgs.openssh_10_2;
     enableDefaultConfig = false;
 
     matchBlocks = {


### PR DESCRIPTION
This pull request makes a targeted update to the SSH configuration, addressing performance issues by specifying a newer OpenSSH package. This is a temporary fix and includes a reminder to remove the package import once the issue is resolved.

* SSH Configuration Update:
  * In `users/profiles/ssh.nix`, sets the SSH package to `pkgs.openssh_10_2` to work around slowness in version 10.1p1.