### PR TITLE
Variable enable, framework fixes, vnc+aio initial

### DIFF
--- a/hosts/x86_64-linux/framenix.nix
+++ b/hosts/x86_64-linux/framenix.nix
@@ -9,7 +9,7 @@
 
   imports = [
     ../../profiles/hardware/usbcore.nix
-    ../../profiles/hardware/amd.nix
+    ../../profiles/hardware/fw_desktop.nix
     ../../profiles/admin-user/home-manager.nix
     ../../profiles/admin-user/user.nix
     ../../profiles/disk/btrfs-on-luks.nix
@@ -18,6 +18,8 @@
     ../../profiles/greetd.nix
     ../../profiles/home-manager.nix
     ../../profiles/k3s-agent.nix
+    ../../profiles/nfs.nix
+    ../../profiles/aio_media.nix
     #../../profiles/restic-backup.nix
     ../../profiles/state.nix
     ../../profiles/tailscale.nix
@@ -38,6 +40,10 @@
   #    path = "/home/${adminUser.name}/.ssh/id_ed25519";
   #  };
   #};
+
+  networking.firewall.allowedTCPPorts = [
+    5900
+  ];
 
   programs.steam.enable = true;
   services.flatpak.enable = true;

--- a/hostvars/default.nix
+++ b/hostvars/default.nix
@@ -1,0 +1,5 @@
+{
+  enableVNC = false;
+
+  modKey = "SUPER";
+}

--- a/hostvars/framenix.nix
+++ b/hostvars/framenix.nix
@@ -1,0 +1,5 @@
+{
+  enableVNC = true;
+
+  modKey = "ALT";
+}

--- a/hostvars/nixbox.nix
+++ b/hostvars/nixbox.nix
@@ -1,0 +1,5 @@
+{
+  enableVNC = false;
+
+  modKey = "SUPER";
+}

--- a/hostvars/nixtzner.nix
+++ b/hostvars/nixtzner.nix
@@ -1,0 +1,5 @@
+{
+  enableVNC = false;
+
+  modKey = "SUPER";
+}

--- a/profiles/aio_media.nix
+++ b/profiles/aio_media.nix
@@ -1,0 +1,80 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+{
+  services.deluge = {
+    enable = true;
+    declarative = true;
+    authFile = "/var/lib/deluge/auth";
+    openFirewall = true;
+    web.enable = true;
+    web.openFirewall = true;
+    config = {
+      download_location = "/mnt/media/torrents/incomplete";
+      dht = false;
+      upnp = false;
+      utpex = false;
+      lsd = false;
+      natpmp = false;
+      copy_torrent_file = true;
+      torrentfiles_location = "/mnt/media/torrents/saved_torrents";
+      move_completed = true;
+      move_completed_path = "/mnt/media/torrents/finished";
+      random_port = false;
+      listen_ports = [
+        57788
+        57788
+      ];
+      enabled_plugins = [
+        "Label"
+        "Stats"
+        "SimpleExtractor"
+      ];
+      max_active_seeding = -1;
+      max_active_downloading = 5;
+      max_active_limit = -1;
+      stop_seed_at_ratio = false;
+      remove_seed_at_ratio = false;
+      stop_seed_ratio = 2.0;
+      share_ratio_limit = 2.0;
+      seed_time_limit = 10080;
+      seed_time_ratio_limit = -1;
+      max_upload_slots_global = -1;
+      dont_count_slow_torrents = true;
+      max_connections_global = 1000;
+      auto_managed = false;
+    };
+  };
+
+  systemd.services.deluged = {
+    after = [
+      "mnt-media.mount"
+    ];
+  };
+
+  services.jellyfin = {
+    enable = true;
+    openFirewall = true;
+    user = "deluge";
+    group = "deluge";
+  };
+
+  environment.systemPackages = with pkgs; [
+    jellyfin-ffmpeg
+  ];
+
+  systemd.services.jellyfin = {
+    after = [ "mnt-media.mount" ];
+  };
+
+  environment.persistence."/keep".directories = [
+    "/var/lib/deluge"
+    "/var/lib/jellyfin"
+    "/var/lib/prowlarr"
+    "/var/lib/radarr"
+    "/var/lib/sonarr"
+  ];
+}

--- a/profiles/greetd.nix
+++ b/profiles/greetd.nix
@@ -1,9 +1,14 @@
 {
+  adminUser,
   pkgs,
   lib,
+  hostName,
   ...
 }:
 let
+  inherit (import ../hostvars/${hostName}.nix)
+    enableVNC
+    ;
   runViaSystemdCat =
     {
       name,
@@ -152,6 +157,8 @@ in
     enable = true;
     restart = true;
     settings = {
+      initial_session.user = lib.mkIf enableVNC "${adminUser.name}";
+      initial_session.command = lib.mkIf enableVNC "${pkgs.hyprland}/bin/Hyprland";
       default_session.command = "${createGreeter "${runHyprland}/bin/Hyprland" sessions}/bin/greeter";
     };
   };

--- a/profiles/hardware/fw_desktop.nix
+++ b/profiles/hardware/fw_desktop.nix
@@ -1,0 +1,10 @@
+{ pkgs, inputs, ... }:
+{
+  imports = [
+    inputs.nixos-hardware.nixosModules.framework-desktop-amd-ai-max-300-series
+  ];
+
+  environment.systemPackages = with pkgs; [
+    btop-rocm
+  ];
+}

--- a/profiles/hardware/nvidia.nix
+++ b/profiles/hardware/nvidia.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   config,
   ...
 }:
@@ -20,4 +21,8 @@
 
   #boot.initrd.kernelModules = [ "nvidia" ];
   #boot.extraModulePackages = [ config.boot.kernelPackages.nvidia_x11 ];
+
+  environment.systemPackages = with pkgs; [
+    btop-cuda
+  ];
 }

--- a/profiles/home-manager.nix
+++ b/profiles/home-manager.nix
@@ -1,10 +1,11 @@
 {
   hostName,
   inputs,
+  adminUser,
   ...
 }:
 {
-  home-manager.extraSpecialArgs = { inherit hostName inputs; };
+  home-manager.extraSpecialArgs = { inherit hostName inputs adminUser; };
   home-manager.sharedModules = [
     ../users/modules/theme.nix
     ../users/modules/userinfo.nix

--- a/profiles/nfs.nix
+++ b/profiles/nfs.nix
@@ -1,0 +1,6 @@
+{
+  fileSystems."/mnt/media" = {
+    device = "192.168.1.5:/volume1/Media";
+    fsType = "nfs";
+  };
+}

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -3,8 +3,13 @@
   config,
   pkgs,
   inputs,
+  hostName,
   ...
 }:
+let
+  inherit (import ../hostvars/${hostName}.nix)
+    ;
+in
 {
   imports = [
     ./defaults.nix

--- a/users/profiles/default.nix
+++ b/users/profiles/default.nix
@@ -39,10 +39,6 @@
     enable = true;
   };
 
-  programs.btop = {
-    enable = true;
-  };
-
   programs.direnv = {
     enable = true;
     nix-direnv.enable = true;

--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -2,9 +2,13 @@
   config,
   lib,
   pkgs,
+  hostName,
   ...
 }:
 let
+  inherit (import ../../hostvars/${hostName}.nix)
+    modKey
+    ;
   screenshot = pkgs.writeShellApplication {
     name = "screenshot";
     runtimeInputs = [ pkgs.hyprshot ];
@@ -149,7 +153,7 @@ in
       "DP-5, preferred, 2880x0, 1, transform, 3"
       #"DP-5, disable"
     ];
-    "$mod" = "SUPER";
+    "$mod" = "${modKey}";
     bind = [
       "$mod, Return, exec, ${terminal-bin}"
       "$mod SHIFT, q, killactive"
@@ -324,7 +328,6 @@ in
     exec-once = [
       "${pkgs.hyprland}/bin/hyprctl setcursor ${xcursor_theme} 24"
       "${pkgs.polkit_gnome.out}/libexec/polkit-gnome-authentication-agent-1"
-      "[workspace 2 silent] ${pkgs.btop}/bin/btop"
       "[workspace 2 silent] ${pkgs.firefox}/bin/firefox"
       "[workspace 4 silent] ${pkgs.signal-desktop}/bin/signal-desktop"
       "[workspace 4 silent] ${pkgs.telegram-desktop}/bin/Telegram"

--- a/users/profiles/vnc.nix
+++ b/users/profiles/vnc.nix
@@ -1,0 +1,13 @@
+{
+  services.wayvnc = {
+    enable = true;
+    autoStart = true;
+    
+    settings = {
+      address = "0.0.0.0";
+      port = 5900;
+      xkb_options = "compose:ralt";
+    };
+  };
+}
+

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -1,10 +1,14 @@
 {
   pkgs,
   config,
+  hostName,
   ...
 }:
 let
   inherit (config) gtk;
+  inherit (import ../../hostvars/${hostName}.nix)
+    enableVNC
+    ;
 in
 {
   imports = [
@@ -17,7 +21,8 @@ in
     ./waybar.nix
     ./vscodium.nix
     ./gnome-keyring.nix
-  ];
+  ]
+  ++ (if enableVNC then [ ./vnc.nix ] else [ ]);
 
   home.packages = with pkgs; [
     nautilus


### PR DESCRIPTION
This pull request introduces several new features and configuration improvements for the `framenix` host and related profiles, focusing on media services, VNC support, hardware integration, and user experience customization. The most significant changes include adding new Nix profiles for media services and NFS mounting, enabling VNC support that is controlled via host-specific variables, updating hardware profiles for better compatibility, and making the Hyprland mod key configurable per host.

**Media & Network Services**
* Added new `aio_media.nix` profile to enable and configure Deluge (torrent client) and Jellyfin (media server), including firewall rules and persistence for service data.
* Introduced `nfs.nix` profile to mount `/mnt/media` from a remote NFS server, supporting the media services.
* Updated `framenix.nix` to import both new profiles, integrating them into the host configuration.

**VNC Support**
* Added a host-specific variable `enableVNC` in `vars/framenix.nix`, and updated `greetd.nix` and user workstation profiles to conditionally enable VNC services and session settings based on this variable. [[1]](diffhunk://#diff-0ce17a3b52ebeb951e6a1250066720c97c56fec20e0026a002f34d7257545b34R1-R5) [[2]](diffhunk://#diff-73e6caec3a657b793c2c700e60378c29cb84d8c62c2351978adbc5fe25a9d34aR2-R11) [[3]](diffhunk://#diff-73e6caec3a657b793c2c700e60378c29cb84d8c62c2351978adbc5fe25a9d34aR160-R161) [[4]](diffhunk://#diff-2afdf65471b3a5a3e7cf1b6d7f1d0d902364e81f3fdadbc3f5916ccf0c18dfeeR1-R13) [[5]](diffhunk://#diff-50e5a3621d610ec5dd15b2b918f7dae8d1c0c50ff9c4a051a4ef5de5932ce4fcR4-R11) [[6]](diffhunk://#diff-50e5a3621d610ec5dd15b2b918f7dae8d1c0c50ff9c4a051a4ef5de5932ce4fcL20-R25)

**Hardware Integration**
* Replaced the AMD hardware profile with a new Framework desktop AMD profile (`fw_desktop.nix`), and added relevant system packages for hardware monitoring. [[1]](diffhunk://#diff-7373447e8aad044d2e1441ce67265f1af10133f0c9c78eb06de8233816255ac8L12-R12) [[2]](diffhunk://#diff-b4d4552d48c8db29f1bdaf673543a8181a06ddb9e505b1a7aab5f0be24440db2R1-R10)
* Updated NVIDIA profile to include `btop-cuda` for CUDA hardware monitoring. [[1]](diffhunk://#diff-3d6c78a12193b2a61da1655c76121bef7ae85f33facd7fb0b7f232011add60ceR2) [[2]](diffhunk://#diff-3d6c78a12193b2a61da1655c76121bef7ae85f33facd7fb0b7f232011add60ceR24-R27)

**User Experience & Customization**
* Made the Hyprland mod key configurable per host by reading it from the host variables, allowing for different key bindings on different machines. [[1]](diffhunk://#diff-a7299bdaca443eb29bdd665691a5b375c5761479895484b8cc628a463860726aR5-R11) [[2]](diffhunk://#diff-a7299bdaca443eb29bdd665691a5b375c5761479895484b8cc628a463860726aL152-R156) [[3]](diffhunk://#diff-ca29ab245917ed2ec8d7ec33aba4b2f6e9ef4e658a445de4e9791be5a1b33c97R1-R3)
* Removed default `btop` launch from Hyprland autostart and user profile, as hardware-specific versions are now used. [[1]](diffhunk://#diff-a7299bdaca443eb29bdd665691a5b375c5761479895484b8cc628a463860726aL327) [[2]](diffhunk://#diff-a9439bb0989edf1b431bed7375969658b9b383cd7682bc82f5e70c5cc0721233L42-L45)

**Miscellaneous**
* Passed `adminUser` to `home-manager` for more flexible user configuration.
* Minor additions to host variables for future extensibility. [[1]](diffhunk://#diff-165cbace6b04d30d525d5b5b277364b64334e13048f62801e51ce89713c9e261R1) [[2]](diffhunk://#diff-0d8740e2c4c27c8e865cf6ba290a303fba54ad1861ab5132fba737274dcd3479R6-R12)

Let me know if you want more details on any of these changes!