### PR TITLE
enable alacritty selection save to clipboard

### DIFF
--- a/users/profiles/alacritty.nix
+++ b/users/profiles/alacritty.nix
@@ -13,6 +13,9 @@
         dynamic_padding = false;
         opacity = 1.0;
       };
+      selection = {
+        save_to_clipboard = true;
+      };
       scrolling = {
         history = 10000;
         multiplier = 3;


### PR DESCRIPTION
This pull request makes a small configuration improvement to the `users/profiles/alacritty.nix` file. The change enables automatic copying of selected text to the clipboard in Alacritty.