### PR TITLE
Better if-handling greetd

### DIFF
--- a/profiles/greetd.nix
+++ b/profiles/greetd.nix
@@ -157,8 +157,10 @@ in
     enable = true;
     restart = true;
     settings = {
-      initial_session.user = lib.mkIf enableVNC "${adminUser.name}";
-      initial_session.command = lib.mkIf enableVNC "${pkgs.hyprland}/bin/Hyprland";
+      initial_session = lib.mkIf enableVNC {
+        user = "${adminUser.name}";
+        command = "${pkgs.hyprland}/bin/Hyprland";
+      };
       default_session.command = "${createGreeter "${runHyprland}/bin/Hyprland" sessions}/bin/greeter";
     };
   };


### PR DESCRIPTION
This pull request makes a small change to the `profiles/greetd.nix` file, improving how the `initial_session` configuration is set up when VNC is enabled. The change replaces setting `user` and `command` separately with a single conditional assignment of the entire `initial_session` attribute set, resulting in cleaner and more maintainable code.