### PR TITLE
acme cf token

### DIFF
--- a/hosts/x86_64-linux/framenix.nix
+++ b/hosts/x86_64-linux/framenix.nix
@@ -68,6 +68,9 @@
       file = ../../secrets/ts.age;
       owner = "1100";
     };
+    acme-cf = {
+      file = ../../secrets/acme-cf.age;
+    };
   };
 
   #services.k3s.settings = {

--- a/secrets/acme-cf.age
+++ b/secrets/acme-cf.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 X0VlDw 9h+noi0fGN/b9hLaK/0z8GhrZw2NFFBv7e0HV8oYpxc
++AWeEQBqY0HP7xraIqCaYgHsZnh0TbauHvFuyClVcSk
+-> ssh-ed25519 u/JGcA rVgZrpwbBTIHaVGjM+OVK8wUtJ40yRilTi4MnoV6eSs
+Co07696m0QeLv53wDGpPSsF6hIhcU0eAqE/mr3yD0ig
+--- 1rS2KYEQVNRpTWvksHgtcieRGrBTkugdu3C6WBJJ2No
+QûGŽ·Â¨?»•¾Dt;XJ^Ï¶à¨ãØ¯ìÙi-…¡IÔéÀèÄ€É›§dD¡fGÚO‡nI¥¹s«èÞL{Í¾ìoÌ˜


### PR DESCRIPTION
This pull request introduces a new secret for ACME certificate management using Cloudflare, and updates the Nix host configuration to reference this secret. The main changes are grouped below:

Secret management:

* Added a new secret file `acme-cf.age` containing encrypted credentials for ACME Cloudflare integration.

Host configuration updates:

* Updated `hosts/x86_64-linux/framenix.nix` to reference the new `acme-cf` secret, enabling services to access Cloudflare credentials for ACME operations.