### PR TITLE
initial lazyvim

### DIFF
--- a/devenv/default.nix
+++ b/devenv/default.nix
@@ -18,12 +18,12 @@ let
     name = "project-build";
     runtimeInputs = [ pkgs.watchexec ];
     text = ''
-      watchexec -r -- 'cake lint; cake dead; cake dscheck'
+      watchexec -r -- 'cronge lint; cronge dead; cronge dscheck'
     '';
   };
 in
 {
-  name = "cake";
+  name = "cronge";
 
   packages = with pkgs; [
     age-plugin-yubikey
@@ -40,7 +40,7 @@ in
 
   enterShell = ansiEscape ''
      echo -e "
-      {bold}{106}Cake{reset}
+      {bold}{106}cronge{reset}
     "
   '';
 }

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
     home-manager.url = "github:nix-community/home-manager";
     hyprland.url = "github:hyprwm/Hyprland";
     impermanence.url = "github:nix-community/impermanence";
+    lazyvim.url = "github:pfassina/lazyvim-nix";
     mk-shell-bin.url = "github:rrbutani/nix-mk-shell-bin";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";
     nix2container.url = "github:nlewo/nix2container";

--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -114,6 +114,11 @@ in
 
   programs.fish.enable = true;
 
+  environment.shellAliases = {
+    vi = "nvim";
+    vim = "nvim";
+  };
+
   programs.command-not-found.dbPath = "${./..}/programs.sqlite";
 
   security.sudo.extraConfig = ''

--- a/users/profiles/default.nix
+++ b/users/profiles/default.nix
@@ -8,8 +8,8 @@
     ./bat.nix
     ./dunst.nix
     ./firefox.nix
+    ./lazyvim.nix
     ./git.nix
-    ./neovim/default.nix
     ./ssh.nix
     ./starship.nix
   ];

--- a/users/profiles/lazyvim.nix
+++ b/users/profiles/lazyvim.nix
@@ -1,0 +1,34 @@
+{
+  inputs,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    inputs.lazyvim.homeManagerModules.default
+  ];
+
+  programs.lazyvim = {
+    enable = true;
+
+    extras = {
+      lang.nix.enable = true;
+      lang.python = {
+        enable = true;
+        installDependencies = true; # Install ruff
+        installRuntimeDependencies = false; # Install python3
+      };
+      lang.go = {
+        enable = true;
+        installDependencies = true; # Install gopls, gofumpt, etc.
+        installRuntimeDependencies = false; # Install go compiler
+      };
+    };
+
+    # Additional packages (optional)
+    extraPackages = with pkgs; [
+      nixd # Nix LSP
+      alejandra # Nix formatter
+    ];
+  };
+}


### PR DESCRIPTION
This pull request introduces significant changes to the development environment, primarily replacing `cake` with `cronge` as the main project tool and adding support for the LazyVim configuration. The changes also improve the shell experience by setting up aliases for `nvim`, and update the user profile to use LazyVim instead of the previous Neovim setup.

**Project tool migration:**
* Swapped out references to `cake` for `cronge` in `devenv/default.nix`, updating the build commands and shell entry message to use the new tool name. [[1]](diffhunk://#diff-a92a71154f891d8f778edc7b51ff236e461167115c754e0a3e0981a4ae3b421cL21-R26) [[2]](diffhunk://#diff-a92a71154f891d8f778edc7b51ff236e461167115c754e0a3e0981a4ae3b421cL43-R43)

**Editor configuration and user profile updates:**
* Added `lazyvim` as a flake input in `flake.nix` and integrated its Home Manager module through a new `users/profiles/lazyvim.nix` file, enabling LazyVim and configuring language support for Nix, Python, and Go, along with extra packages for Nix development. [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R50) [[2]](diffhunk://#diff-43103b50fc51f1c2aaa4a0fbf69ea9f663b5c7c4d3f14c2055d497c74f34f7d1R1-R34)
* Updated `users/profiles/default.nix` to include the new `lazyvim.nix` profile and remove the previous Neovim configuration.

**Shell experience improvements:**
* Added shell aliases for `vi` and `vim` to point to `nvim` in `profiles/defaults.nix`, ensuring consistent editor usage.