### PR TITLE
git-delta enabled and state nvim

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -70,6 +70,7 @@
         ".local/share/lutris"
         ".local/share/keyrings"
         ".local/share/nix"
+        ".local/share/nvim"
         ".local/share/vulkan"
         ".local/share/zoxide"
         ".local/state/pipewire/media-session.d"

--- a/users/profiles/git.nix
+++ b/users/profiles/git.nix
@@ -48,6 +48,7 @@
 
   programs.delta = {
     enable = true;
+    enableGitIntegration = true;
     options = {
       features = "decorations side-by-side line-numbers";
     };


### PR DESCRIPTION
This pull request introduces minor configuration updates to improve user experience and environment consistency.

Configuration improvements:

* Added `.local/share/nvim` to the persisted state directories in `profiles/state.nix`, ensuring Neovim data is maintained across sessions.
* Enabled Git integration for the `delta` program in `users/profiles/git.nix`, enhancing the visual output of git diffs.