### PR TITLE
aio media improvements

### DIFF
--- a/hosts/x86_64-linux/framenix.nix
+++ b/hosts/x86_64-linux/framenix.nix
@@ -43,6 +43,7 @@
 
   networking.firewall.allowedTCPPorts = [
     5900
+    443
   ];
 
   programs.steam.enable = true;

--- a/secrets/acme-cf.age
+++ b/secrets/acme-cf.age
@@ -1,7 +1,8 @@
 age-encryption.org/v1
--> ssh-ed25519 X0VlDw 9h+noi0fGN/b9hLaK/0z8GhrZw2NFFBv7e0HV8oYpxc
-+AWeEQBqY0HP7xraIqCaYgHsZnh0TbauHvFuyClVcSk
--> ssh-ed25519 u/JGcA rVgZrpwbBTIHaVGjM+OVK8wUtJ40yRilTi4MnoV6eSs
-Co07696m0QeLv53wDGpPSsF6hIhcU0eAqE/mr3yD0ig
---- 1rS2KYEQVNRpTWvksHgtcieRGrBTkugdu3C6WBJJ2No
-QûGŽ·Â¨?»•¾Dt;XJ^Ï¶à¨ãØ¯ìÙi-…¡IÔéÀèÄ€É›§dD¡fGÚO‡nI¥¹s«èÞL{Í¾ìoÌ˜
+-> ssh-ed25519 X0VlDw P7GdZBSYwZo7NalU6oM7xC++p6HDRWwhEVZkJGmSEXE
+63j5MGpC7NHO68X6cMDE9v05qqz9cpJYamZ69mDMmVU
+-> ssh-ed25519 u/JGcA ZFo18HcRd+Shr/Co5DvP9VqhzjtpEa5xAMw9ksvNZVU
+BJjWVJAjIBCDWa+zJqhUt4CeuRXvEqrdHQXZBaaDJG0
+--- 3EPF1xAMJXH62S0/ElusJy6NK4pONHDrE2BnGYQxnwA
+f‹8lé¥
+AmÏi+(ÔÓÆá»›£¹›ºû‘£$šNóôŽñˆOü«ºÕÑ”wSôÖ`Ž	Ãj¨éT2Sn‰îÇ³àdo£ªÍâìåPf§t	9:–DÝ?w[¡


### PR DESCRIPTION
This pull request makes significant updates to the media server profile, focusing on service consolidation, improved reverse proxy and SSL certificate management, and user/group configuration. The legacy Deluge setup is replaced with a more unified configuration for multiple media-related services, leveraging Caddy for reverse proxying and automated SSL via ACME with Cloudflare DNS. Persistence and firewall settings are also updated to support these changes.

**Service consolidation and migration:**
* Replaced legacy Deluge configuration with a declarative setup for `qbittorrent`, including detailed server and torrenting settings, and migrated all media services (`jellyfin`, `sonarr`, `radarr`, `prowlarr`, `flaresolverr`, `jellyseerr`) to use a dedicated `media` user and group for improved isolation and maintainability.

**Reverse proxy and SSL automation:**
* Added a list of domain/port pairs (`acmehosts`) and used it to automatically generate Caddy virtual hosts and ACME certificate entries, enabling reverse proxying with TLS 1.3 for all media services using certificates managed via Cloudflare DNS.
* Updated the ACME secret file (`secrets/acme-cf.age`) with new encrypted keys for Cloudflare DNS integration.

**Persistence and systemd improvements:**
* Updated persistent directories to include all relevant service data and ACME/Caddy state, and refactored systemd service configurations to ensure correct user/group assignments and mount dependencies for media storage.

**Firewall configuration:**
* Opened TCP port 443 on the firewall to support HTTPS traffic for the reverse proxy.