### PR TITLE
fw desktop unified ram and lil aio fixes

### DIFF
--- a/hosts/x86_64-linux/framenix.nix
+++ b/hosts/x86_64-linux/framenix.nix
@@ -13,7 +13,7 @@
     ../../profiles/admin-user/home-manager.nix
     ../../profiles/admin-user/user.nix
     ../../profiles/disk/btrfs-on-luks.nix
-    ../../profiles/uuid_disk_crypt.nix 
+    ../../profiles/uuid_disk_crypt.nix
     ../../profiles/desktop.nix
     ../../profiles/greetd.nix
     ../../profiles/home-manager.nix
@@ -32,6 +32,12 @@
     systemd.enable = true;
   };
 
+  boot.kernelParams = [
+    # Kernel params set according to https://github.com/rjmalagon/ollama-linux-amd-apu
+    # https://wiki.archlinux.org/title/Framework_Desktop#Unified_memory
+    "ttm.pages_limit=4194304"
+    "ttm.page_pool_size=4194304"
+  ];
 
   #age.secrets = {
   #  id_ed25519 = {

--- a/profiles/aio_media.nix
+++ b/profiles/aio_media.nix
@@ -91,7 +91,7 @@ in
           MaxUploads = 40;
           MaxUploadsPerTorrent = 10;
           Port = 63333;
-          QueueingSystemEnabled = false;
+          QueueingSystemEnabled = true;
           ShareLimitAction = "Stop";
           TempPath = "/mnt/media/qb/temp";
           TempPathEnabled = true;
@@ -244,6 +244,7 @@ in
       "/var/lib/acme"
       "/var/lib/caddy"
       "/var/lib/jellyfin"
+      "/var/cache/jellyfin/" # transcoding hurts
       "/var/lib/jellyseerr"
       "/var/lib/prowlarr"
       "/var/lib/radarr"


### PR DESCRIPTION
This pull request introduces several configuration improvements for system performance and media management. The most notable changes are the addition of kernel parameters to optimize unified memory usage and updates to media service settings for improved handling and caching.

System performance optimization:

* Added kernel parameters `ttm.pages_limit=4194304` and `ttm.page_pool_size=4194304` in `framenix.nix` to enhance unified memory support for AMD APUs, following recommendations from upstream resources.

Media service configuration improvements:

* Enabled the queueing system in the media profile by setting `QueueingSystemEnabled` to `true` for better upload management in `aio_media.nix`.
* Added `/var/cache/jellyfin/` to the list of persistent directories to address transcoding performance issues with Jellyfin.