### PR TITLE
Removal k3s disable

### DIFF
--- a/modules/k3s.nix
+++ b/modules/k3s.nix
@@ -131,19 +131,19 @@ in
     default = [ ];
   };
 
-  options.services.k3s.disable = mkOption {
-    type = types.listOf (
-      types.enum [
-        "coredns"
-        "servicelb"
-        "traefik"
-        "local-storage"
-        "metrics-server"
-        "runtimes"
-      ]
-    );
-    default = [ ];
-  };
+  #  options.services.k3s.disable = mkOption {
+  #    type = types.listOf (
+  #      types.enum [
+  #        "coredns"
+  #        "servicelb"
+  #        "traefik"
+  #        "local-storage"
+  #        "metrics-server"
+  #        "runtimes"
+  #      ]
+  #    );
+  #    default = [ ];
+  #  };
 
   options.services.k3s.settings = mkOption {
     type = types.attrsOf types.anything;
@@ -195,9 +195,6 @@ in
                     name: path:
                     "${pkgs.gettext}/bin/envsubst '${cfg.allowedReplacementVars}' < ${path} > ${k3sManifestsDir}/${name}.yaml"
                   ) cfg.autoDeploy
-                )}
-                ${concatStringsSep "\n" (
-                  map (manifestName: "touch ${k3sManifestsDir}/${manifestName}.yaml.skip") cfg.disable
                 )}
               ''
             else


### PR DESCRIPTION
This pull request makes changes to the `modules/k3s.nix` file, primarily deprecating the `disable` option for the `services.k3s` module and removing related logic that handled disabling specific K3s components.

Key changes:

**Deprecation and removal of the `disable` option:**

* The `services.k3s.disable` option, which previously allowed users to disable specific K3s components (like `coredns`, `servicelb`, etc.), has been commented out, effectively deprecating this configuration option.
* The code that created `.yaml.skip` files for each disabled manifest (based on the `disable` option) has been removed, as this logic is no longer necessary without the `disable` option.