### PR TITLE
fix for hyprland windowrule+layerrule cfg change

### DIFF
--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -284,8 +284,8 @@ in
     };
 
     layerrule = [
-      "blur,waybar"
-      "ignorealpha,waybar"
+      "match:workspace waybar, blur off"
+      "match:workspace waybar, ignore_alpha on"
     ];
 
     input = {
@@ -307,18 +307,14 @@ in
       no_update_news = true;
     };
 
-    windowrulev2 = [
-      "dimaround,class:gitui"
-      "float,class:gitui"
-      "size 60% 60%,class:gitui"
-      "center,class:gitui"
-      "dimaround,class:chrome-nngceckbapebfimnlniiiahkandclblb-Default"
-      "float,class:chrome-nngceckbapebfimnlniiiahkandclblb-Default"
-      "size 60% 60%,class:chrome-nngceckbapebfimnlniiiahkandclblb-Default"
-      "center,class:chrome-nngceckbapebfimnlniiiahkandclblb-Default"
-      "dimaround,title:Open File"
-      "float,title:Open File"
-      "center,title:Open File"
+    windowrule = [
+      "dim_around on,match:class gitui"
+      "float on,match:class gitui"
+      "size 60% 60%,match:class gitui"
+      "center on,match:class gitui"
+      "dim_around on,match:title Open File"
+      "float on,match:title Open File"
+      "center on,match:title Open File"
     ];
 
     exec = [


### PR DESCRIPTION
This pull request updates the Hyprland configuration to use the new syntax for defining layer and window rules. The changes primarily focus on improving compatibility and clarity by migrating from the old `layerrule` and `windowrulev2` directives to the newer `layerrule` and `windowrule` formats with explicit matching and options.

**Migration to new Hyprland configuration syntax:**

* Updated `layerrule` entries to use the new `match:` syntax and explicit options like `blur off` and `ignore_alpha on` for the `waybar` workspace.
* Replaced the deprecated `windowrulev2` array with the new `windowrule` array, updating rules for applications like `gitui` and windows with the title `Open File` to use the new option syntax (e.g., `dim_around on`, `float on`, `center on`) and `match:` selectors.