### PR TITLE
feat: wooting udev rules

### DIFF
--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -93,7 +93,10 @@ in
     dconf
     sushi
   ];
-  services.udev.packages = with pkgs; [ gnome-settings-daemon ];
+  services.udev.packages = with pkgs; [
+    wooting-udev-rules
+    gnome-settings-daemon
+  ];
 
   services.pipewire = {
     enable = true;


### PR DESCRIPTION
This pull request makes a small update to the `profiles/workstation.nix` configuration file by adding support for Wooting keyboard udev rules. This ensures proper device handling for Wooting keyboards.

* Added `wooting-udev-rules` to the `services.udev.packages` list to enable correct udev support for Wooting keyboards.