### PR TITLE
feat: start-hyprland

### DIFF
--- a/profiles/greetd.nix
+++ b/profiles/greetd.nix
@@ -73,7 +73,7 @@ let
       XDG_SESSION_DESKTOP = "Hyprland";
     };
     name = "Hyprland";
-    cmd = "${pkgs.hyprland}/bin/Hyprland";
+    cmd = "${pkgs.hyprland}/bin/start-hyprland";
   };
 
   desktopSession =
@@ -159,7 +159,7 @@ in
     settings = {
       initial_session = lib.mkIf enableVNC {
         user = "${adminUser.name}";
-        command = "${pkgs.hyprland}/bin/Hyprland";
+        command = "${pkgs.hyprland}/bin/start-hyprland";
       };
       default_session.command = "${createGreeter "${runHyprland}/bin/Hyprland" sessions}/bin/greeter";
     };


### PR DESCRIPTION
This pull request updates the way Hyprland is launched in the `profiles/greetd.nix` configuration. Instead of calling the `Hyprland` binary directly, it now uses the `start-hyprland` wrapper for improved session startup compatibility.

**Hyprland session startup changes:**

* Changed the `cmd` field in the Hyprland session definition to use `${pkgs.hyprland}/bin/start-hyprland` instead of `${pkgs.hyprland}/bin/Hyprland`.
* Updated the `initial_session.command` in the greetd settings to use `${pkgs.hyprland}/bin/start-hyprland` instead of `${pkgs.hyprland}/bin/Hyprland`.