### PR TITLE
chore(seerr): jellyseerr renamed

### DIFF
--- a/profiles/aio_media.nix
+++ b/profiles/aio_media.nix
@@ -143,7 +143,7 @@ in
     jellyfin-ffmpeg
   ];
 
-  services.jellyseerr = {
+  services.seerr = {
     enable = true;
   };
 
@@ -210,7 +210,7 @@ in
       after = [ "mnt-media.mount" ];
     };
 
-    jellyseerr = {
+    seerr = {
       after = [ "mnt-media.mount" ];
       serviceConfig = {
         DynamicUser = lib.mkForce false;


### PR DESCRIPTION
This pull request updates the configuration in `profiles/aio_media.nix` to rename the `jellyseerr` service to `seerr` for consistency. The changes ensure that all references to the service use the new name.

Service renaming:

* Renamed the service definition from `jellyseerr` to `seerr` in the main services section to standardize naming.
* Updated the dependent systemd service configuration from `jellyseerr` to `seerr` to match the new service name.