### PR TITLE
fix: silence k3s and gtk4 theme evaluation warnings

### DIFF
--- a/hosts/x86_64-linux/nixbox.nix
+++ b/hosts/x86_64-linux/nixbox.nix
@@ -66,8 +66,10 @@
     };
   };
 
-  services.k3s.settings = {
-    server = lib.mkForce "";
-    node-external-ip = lib.mkForce "\"$(get-iface-ip enp14s0)\"";
+  services.k3s = {
+    serverAddr = lib.mkForce "";
+    settings = {
+      node-external-ip = lib.mkForce "\"$(get-iface-ip enp14s0)\"";
+    };
   };
 }

--- a/profiles/k3s.nix
+++ b/profiles/k3s.nix
@@ -45,14 +45,14 @@
 
   services.k3s = {
     enable = true;
+    serverAddr = "https://nixbox.tail754457.ts.net:6443";
+    tokenFile = "/run/agenix/k3s-token";
     after = [
       "tailscale-auth.service"
       "metadata.service"
     ];
     settings = {
-      token-file = "/run/agenix/k3s-token";
       node-name = hostName;
-      server = "https://nixbox.tail754457.ts.net:6443";
       node-ip = "\"$(get-iface-ip tailscale0)\"";
       node-external-ip = "\"$(get-default-route-ip)\"";
       node-label."topology.kubernetes.io/region" = "\"$REGION\"";

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -98,5 +98,6 @@ in
       package = pkgs.nordic;
       name = "Nordic-darker";
     };
+    gtk4.theme = null;
   };
 }


### PR DESCRIPTION
This pull request makes several updates to the NixOS configuration for `k3s` and the workstation user profile. The main changes involve restructuring how `k3s` server address and token file are configured, as well as a minor adjustment to the GTK theme settings for the workstation.

**K3s configuration improvements:**

* Refactored the `k3s` service configuration in `hosts/x86_64-linux/nixbox.nix` to use `serverAddr` instead of `settings.server`, aligning with the new configuration structure.
* Updated `profiles/k3s.nix` to explicitly set `serverAddr` and `tokenFile` at the top level of the `services.k3s` attribute, removing their previous placement under `settings`. This clarifies the configuration and ensures compatibility with the latest module options.

**Workstation user profile update:**

* Set `gtk4.theme` to `null` in `users/profiles/workstation.nix` to prevent GTK4 from attempting to use an incompatible or unavailable theme, likely improving desktop stability or appearance.