### PR TITLE
feat(vnc): proper vnc implementation

### DIFF
--- a/profiles/greetd.nix
+++ b/profiles/greetd.nix
@@ -76,6 +76,101 @@ let
     cmd = "${pkgs.hyprland}/bin/start-hyprland";
   };
 
+  # VNC wrapper: starts Hyprland, waits for its socket, creates a headless
+  # output, launches wayvnc, then waits on Hyprland so greetd tracks the
+  # session lifetime correctly.
+  runHyprlandVNC = pkgs.writeShellApplication {
+    name = "HyprlandVNC";
+    runtimeInputs = [
+      pkgs.hyprland
+      pkgs.wayvnc
+      pkgs.jq
+      pkgs.coreutils
+      pkgs.findutils
+    ];
+    text = ''
+      export XDG_SESSION_TYPE="wayland"
+      export XDG_CURRENT_DESKTOP="Hyprland"
+      export XDG_SESSION_DESKTOP="Hyprland"
+
+      if [ -e /etc/profiles/per-user/"$USER"/etc/profile.d/hm-session-vars.sh ]; then
+        set +u
+        # shellcheck disable=SC1090
+        source /etc/profiles/per-user/"$USER"/etc/profile.d/hm-session-vars.sh
+        set -u
+      fi
+
+      XDG_RUNTIME_DIR="''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+      # Start Hyprland in the background
+      start-hyprland &
+      HYPRLAND_PID=$!
+
+      # Wait for the Hyprland IPC socket to appear
+      INSTANCE_DIR=""
+      for _i in $(seq 1 30); do
+        INSTANCE_DIR=$(find "$XDG_RUNTIME_DIR/hypr/" -maxdepth 1 -mindepth 1 -type d -newer "/proc/$HYPRLAND_PID" 2>/dev/null | head -1 || true)
+        if [ -n "$INSTANCE_DIR" ] && [ -e "$INSTANCE_DIR/.socket.sock" ]; then
+          break
+        fi
+        INSTANCE_DIR=""
+        sleep 0.5
+      done
+
+      if [ -z "$INSTANCE_DIR" ]; then
+        echo "ERROR: Hyprland socket did not appear within 15s" >&2
+        kill "$HYPRLAND_PID" 2>/dev/null || true
+        exit 1
+      fi
+
+      export HYPRLAND_INSTANCE_SIGNATURE
+      HYPRLAND_INSTANCE_SIGNATURE=$(basename "$INSTANCE_DIR")
+
+      # Discover WAYLAND_DISPLAY for wayvnc
+      WAYLAND_DISPLAY=""
+      for _i in $(seq 1 10); do
+        for sock in "$XDG_RUNTIME_DIR"/wayland-*; do
+          case "$sock" in
+            *.lock) continue ;;
+          esac
+          if [ -e "$sock" ]; then
+            WAYLAND_DISPLAY=$(basename "$sock")
+            break
+          fi
+        done
+        [ -n "$WAYLAND_DISPLAY" ] && break
+        sleep 0.5
+      done
+      export WAYLAND_DISPLAY
+
+      if [ -z "$WAYLAND_DISPLAY" ]; then
+        echo "ERROR: WAYLAND_DISPLAY not found" >&2
+        kill "$HYPRLAND_PID" 2>/dev/null || true
+        exit 1
+      fi
+
+      # Create a headless output if none exists
+      existing=$(hyprctl monitors -j | jq -r '[.[] | select(.name | startswith("HEADLESS-"))][0].name // empty')
+      if [ -z "$existing" ]; then
+        hyprctl output create headless
+        sleep 1
+        existing=$(hyprctl monitors -j | jq -r '[.[] | select(.name | startswith("HEADLESS-"))][0].name // empty')
+      fi
+
+      if [ -z "$existing" ]; then
+        echo "ERROR: Failed to get a headless monitor" >&2
+        kill "$HYPRLAND_PID" 2>/dev/null || true
+        exit 1
+      fi
+
+      # Launch wayvnc in the background bound to the headless output
+      wayvnc --gpu --max-fps=60 --render-cursor -o "$existing" &
+
+      # Wait on Hyprland so greetd tracks session lifetime
+      wait "$HYPRLAND_PID"
+    '';
+  };
+
   desktopSession =
     name: command:
     pkgs.writeText "${name}.desktop" ''
@@ -159,7 +254,7 @@ in
     settings = {
       initial_session = lib.mkIf enableVNC {
         user = "${adminUser.name}";
-        command = "${pkgs.hyprland}/bin/start-hyprland";
+        command = "${runHyprlandVNC}/bin/HyprlandVNC";
       };
       default_session.command = "${createGreeter "${runHyprland}/bin/Hyprland" sessions}/bin/greeter";
     };

--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -8,6 +8,7 @@
 let
   inherit (import ../../hostvars/${hostName}.nix)
     modKey
+    enableVNC
     ;
   screenshot = pkgs.writeShellApplication {
     name = "screenshot";
@@ -134,25 +135,38 @@ in
     bind=,return,submap,reset
     submap=reset
 
-    workspace=1,monitor:DP-3,default:true
-    workspace=3,monitor:DP-3
-    workspace=5,monitor:DP-3
+    ${
+      if enableVNC then
+        ""
+      else
+        ''
+          workspace=1,monitor:DP-3,default:true
+          workspace=3,monitor:DP-3
+          workspace=5,monitor:DP-3
 
-    workspace=7,monitor:DP-5,default:true,layoutopt:orientation:top
-    workspace=9,monitor:DP-5,layoutopt:orientation:bottom
+          workspace=7,monitor:DP-5,default:true,layoutopt:orientation:top
+          workspace=9,monitor:DP-5,layoutopt:orientation:bottom
 
-    workspace=2,monitor:DP-4,default:true,layoutopt:orientation:bottom
-    workspace=4,monitor:DP-4,layoutopt:orientation:top
+          workspace=2,monitor:DP-4,default:true,layoutopt:orientation:bottom
+          workspace=4,monitor:DP-4,layoutopt:orientation:top
+        ''
+    }
   '';
 
   wayland.windowManager.hyprland.settings = {
-    monitor = [
-      "DP-3, preferred, 0x0, 1.33"
-      "DP-4, preferred, -1440x0, 1, transform, 1"
-      #"DP-4, disable"
-      "DP-5, preferred, 2880x0, 1, transform, 3"
-      #"DP-5, disable"
-    ];
+    monitor =
+      if enableVNC then
+        [
+          ", 1920x1080@60, 0x0, 1"
+        ]
+      else
+        [
+          "DP-3, preferred, 0x0, 1.33"
+          "DP-4, preferred, -1440x0, 1, transform, 1"
+          #"DP-4, disable"
+          "DP-5, preferred, 2880x0, 1, transform, 3"
+          #"DP-5, disable"
+        ];
     "$mod" = "${modKey}";
     bind = [
       "$mod, Return, exec, ${terminal-bin}"
@@ -324,13 +338,25 @@ in
     exec-once = [
       "${pkgs.hyprland}/bin/hyprctl setcursor ${xcursor_theme} 24"
       "${pkgs.polkit_gnome.out}/libexec/polkit-gnome-authentication-agent-1"
-      "[workspace 2 silent] ${pkgs.firefox}/bin/firefox"
-      "[workspace 4 silent] ${pkgs.signal-desktop}/bin/signal-desktop"
-      "[workspace 4 silent] ${pkgs.telegram-desktop}/bin/Telegram"
-      "[workspace 4 silent] ${pkgs.spotify}/bin/spotify"
-      "[workspace 5 silent] ${pkgs.steam}/bin/steam"
-      "[workspace 5 silent] ${pkgs.lutris}/bin/lutris"
-      "[workspace 7 silent] ${pkgs.vesktop}/bin/vesktop"
-    ];
+    ]
+    ++ (
+      if enableVNC then
+        [
+          "[workspace 1 silent] ${pkgs.firefox}/bin/firefox"
+          "[workspace 2 silent] ${pkgs.signal-desktop}/bin/signal-desktop"
+          "[workspace 2 silent] ${pkgs.telegram-desktop}/bin/Telegram"
+          "[workspace 2 silent] ${pkgs.vesktop}/bin/vesktop"
+        ]
+      else
+        [
+          "[workspace 2 silent] ${pkgs.firefox}/bin/firefox"
+          "[workspace 4 silent] ${pkgs.signal-desktop}/bin/signal-desktop"
+          "[workspace 4 silent] ${pkgs.telegram-desktop}/bin/Telegram"
+          "[workspace 4 silent] ${pkgs.spotify}/bin/spotify"
+          "[workspace 5 silent] ${pkgs.steam}/bin/steam"
+          "[workspace 5 silent] ${pkgs.lutris}/bin/lutris"
+          "[workspace 7 silent] ${pkgs.vesktop}/bin/vesktop"
+        ]
+    );
   };
 }

--- a/users/profiles/vnc.nix
+++ b/users/profiles/vnc.nix
@@ -1,13 +1,10 @@
+{ pkgs, ... }:
 {
-  services.wayvnc = {
-    enable = true;
-    autoStart = true;
-    
-    settings = {
-      address = "0.0.0.0";
-      port = 5900;
-      xkb_options = "compose:ralt";
-    };
-  };
-}
+  home.packages = [ pkgs.wayvnc ];
 
+  xdg.configFile."wayvnc/config".text = ''
+    address=0.0.0.0
+    port=5900
+    xkb_options=compose:ralt
+  '';
+}


### PR DESCRIPTION
This pull request introduces support for running Hyprland in a headless mode suitable for VNC sessions and adds conditional configuration throughout the Hyprland and VNC profiles to enable or disable VNC-specific settings. The main changes include a new shell wrapper to launch Hyprland with wayvnc, adjustments to session and monitor configuration when VNC is enabled, and a simplification of wayvnc configuration management.

**VNC Session Support and Integration:**

* Added a `runHyprlandVNC` shell wrapper in `profiles/greetd.nix` that starts Hyprland, ensures its IPC socket is available, creates a headless output if needed, launches wayvnc, and manages session lifetime for greetd.
* Updated the greetd initial session command to use the new `runHyprlandVNC` wrapper when VNC is enabled, ensuring the session is properly tracked and VNC-ready.
* Added an `enableVNC` flag to the Hyprland user profile to allow conditional configuration based on whether VNC is active.

**Conditional Hyprland Configuration for VNC:**

* Modified workspace and monitor assignments in the Hyprland configuration to use a single headless monitor and simplified workspace layout when VNC is enabled, otherwise retaining the multi-monitor setup. [[1]](diffhunk://#diff-a7299bdaca443eb29bdd665691a5b375c5761479895484b8cc628a463860726aR138-R142) [[2]](diffhunk://#diff-a7299bdaca443eb29bdd665691a5b375c5761479895484b8cc628a463860726aR152-R163)
* Adjusted the `exec-once` autostart applications: when VNC is enabled, key applications are started on workspaces 1 and 2 only; otherwise, the more extensive default set is used.

**WayVNC Configuration Management:**

* Removed the wayvnc systemd service and replaced it with a static configuration file in the user's XDG config directory, simplifying deployment and making it compatible with the new wrapper-based startup.