### PR TITLE
feat(vnc): back to wayvnc service

### DIFF
--- a/profiles/greetd.nix
+++ b/profiles/greetd.nix
@@ -76,15 +76,14 @@ let
     cmd = "${pkgs.hyprland}/bin/start-hyprland";
   };
 
-  # VNC wrapper: starts Hyprland, waits for its socket, creates a headless
-  # output, launches wayvnc, then waits on Hyprland so greetd tracks the
-  # session lifetime correctly.
+  # VNC session: starts Hyprland headlessly and creates a virtual output.
+  # wayvnc is managed by home-manager's services.wayvnc systemd user service,
+  # which auto-starts once hyprland-session.target is reached (triggered by
+  # Hyprland's exec-once after the headless output exists).
   runHyprlandVNC = pkgs.writeShellApplication {
     name = "HyprlandVNC";
     runtimeInputs = [
       pkgs.hyprland
-      pkgs.wayvnc
-      pkgs.jq
       pkgs.coreutils
       pkgs.findutils
     ];
@@ -101,72 +100,23 @@ let
       fi
 
       XDG_RUNTIME_DIR="''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+      export XDG_RUNTIME_DIR
 
-      # Start Hyprland in the background
       start-hyprland &
       HYPRLAND_PID=$!
 
-      # Wait for the Hyprland IPC socket to appear
-      INSTANCE_DIR=""
+      # Wait for Hyprland socket, then create headless output
       for _i in $(seq 1 30); do
-        INSTANCE_DIR=$(find "$XDG_RUNTIME_DIR/hypr/" -maxdepth 1 -mindepth 1 -type d -newer "/proc/$HYPRLAND_PID" 2>/dev/null | head -1 || true)
-        if [ -n "$INSTANCE_DIR" ] && [ -e "$INSTANCE_DIR/.socket.sock" ]; then
+        SOCKET=$(find "$XDG_RUNTIME_DIR/hypr/" -name ".socket.sock" -newer "/proc/$HYPRLAND_PID" 2>/dev/null | head -1 || true)
+        if [ -n "$SOCKET" ]; then
+          export HYPRLAND_INSTANCE_SIGNATURE
+          HYPRLAND_INSTANCE_SIGNATURE=$(basename "$(dirname "$SOCKET")")
+          hyprctl output create headless
           break
         fi
-        INSTANCE_DIR=""
         sleep 0.5
       done
 
-      if [ -z "$INSTANCE_DIR" ]; then
-        echo "ERROR: Hyprland socket did not appear within 15s" >&2
-        kill "$HYPRLAND_PID" 2>/dev/null || true
-        exit 1
-      fi
-
-      export HYPRLAND_INSTANCE_SIGNATURE
-      HYPRLAND_INSTANCE_SIGNATURE=$(basename "$INSTANCE_DIR")
-
-      # Discover WAYLAND_DISPLAY for wayvnc
-      WAYLAND_DISPLAY=""
-      for _i in $(seq 1 10); do
-        for sock in "$XDG_RUNTIME_DIR"/wayland-*; do
-          case "$sock" in
-            *.lock) continue ;;
-          esac
-          if [ -e "$sock" ]; then
-            WAYLAND_DISPLAY=$(basename "$sock")
-            break
-          fi
-        done
-        [ -n "$WAYLAND_DISPLAY" ] && break
-        sleep 0.5
-      done
-      export WAYLAND_DISPLAY
-
-      if [ -z "$WAYLAND_DISPLAY" ]; then
-        echo "ERROR: WAYLAND_DISPLAY not found" >&2
-        kill "$HYPRLAND_PID" 2>/dev/null || true
-        exit 1
-      fi
-
-      # Create a headless output if none exists
-      existing=$(hyprctl monitors -j | jq -r '[.[] | select(.name | startswith("HEADLESS-"))][0].name // empty')
-      if [ -z "$existing" ]; then
-        hyprctl output create headless
-        sleep 1
-        existing=$(hyprctl monitors -j | jq -r '[.[] | select(.name | startswith("HEADLESS-"))][0].name // empty')
-      fi
-
-      if [ -z "$existing" ]; then
-        echo "ERROR: Failed to get a headless monitor" >&2
-        kill "$HYPRLAND_PID" 2>/dev/null || true
-        exit 1
-      fi
-
-      # Launch wayvnc in the background bound to the headless output
-      wayvnc --gpu --max-fps=60 --render-cursor -o "$existing" &
-
-      # Wait on Hyprland so greetd tracks session lifetime
       wait "$HYPRLAND_PID"
     '';
   };

--- a/users/profiles/vnc.nix
+++ b/users/profiles/vnc.nix
@@ -1,10 +1,19 @@
-{ pkgs, ... }:
 {
-  home.packages = [ pkgs.wayvnc ];
+  services.wayvnc = {
+    enable = true;
+    autoStart = true;
 
-  xdg.configFile."wayvnc/config".text = ''
-    address=0.0.0.0
-    port=5900
-    xkb_options=compose:ralt
-  '';
+    settings = {
+      address = "0.0.0.0";
+      port = 5900;
+      xkb_layout = "us";
+      xkb_variant = "altgr-intl";
+      xkb_options = "compose:ralt";
+    };
+  };
+
+  systemd.user.services.wayvnc.Service = {
+    Restart = "always";
+    RestartSec = 10;
+  };
 }


### PR DESCRIPTION
This pull request refactors how the Hyprland VNC session and WayVNC service are managed, simplifying the session startup logic and shifting WayVNC management to Home Manager's systemd user services. The changes improve reliability, modularity, and maintainability of the VNC session setup.

**VNC Session Startup Refactor and Service Management**

* Simplified the `runHyprlandVNC` script to only start Hyprland and create a headless output, removing direct management of WayVNC and related socket/monitor discovery logic. The script now relies on Home Manager's systemd user service to start WayVNC automatically when Hyprland is ready. [[1]](diffhunk://#diff-73e6caec3a657b793c2c700e60378c29cb84d8c62c2351978adbc5fe25a9d34aL79-L87) [[2]](diffhunk://#diff-73e6caec3a657b793c2c700e60378c29cb84d8c62c2351978adbc5fe25a9d34aR103-L169)

* Updated the VNC user profile (`users/profiles/vnc.nix`) to enable and configure the `services.wayvnc` Home Manager module, including settings for address, port, keyboard layout, and auto-start. Added systemd user service options to ensure WayVNC restarts automatically.

**Dependency and Configuration Cleanup**

* Removed unnecessary runtime dependencies (`wayvnc`, `jq`) from the `runHyprlandVNC` script, as WayVNC is now managed separately and direct JSON parsing is no longer required.

* Replaced the manual configuration of WayVNC via `xdg.configFile` with the Home Manager module's declarative `settings` attribute for improved maintainability.