### PR TITLE
feat(ai): initial claude/opencode

### DIFF
--- a/users/profiles/ai.nix
+++ b/users/profiles/ai.nix
@@ -1,7 +1,6 @@
-{ pkgs, ... }:
 {
-  home.packages = with pkgs; [
-    claude-code
-    opencode
+  imports = [
+    ./claude.nix
+    ./opencode.nix
   ];
 }

--- a/users/profiles/claude.nix
+++ b/users/profiles/claude.nix
@@ -1,0 +1,30 @@
+{
+  programs.claude-code = {
+    enable = true;
+    settings = {
+      model = "opus";
+      permissions = {
+        allow = [
+          "Bash(git diff:*)"
+          "Bash(git log:*)"
+          "Bash(git status:*)"
+          "Bash(git blame:*)"
+          "Bash(nix build:*)"
+          "Bash(nix flake:*)"
+          "Bash(nix fmt:*)"
+          "Bash(nix eval:*)"
+          "Edit"
+          "Read"
+          "Grep"
+          "Glob"
+          "Write"
+        ];
+        deny = [
+          "Bash(curl:*)"
+          "Read(./.env)"
+          "Read(./secrets/**)"
+        ];
+      };
+    };
+  };
+}

--- a/users/profiles/opencode.nix
+++ b/users/profiles/opencode.nix
@@ -1,0 +1,11 @@
+{
+  programs.opencode = {
+    enable = true;
+    settings = {
+      autoupdate = false;
+    };
+    tui = {
+      theme = "system";
+    };
+  };
+}

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -19,7 +19,6 @@ in
     ./lutris.nix
     ./rofi.nix
     ./waybar.nix
-    ./vscodium.nix
     ./gnome-keyring.nix
   ]
   ++ (if enableVNC then [ ./vnc.nix ] else [ ]);


### PR DESCRIPTION
This pull request refactors the way the `claude-code` and `opencode` programs are configured in user profiles by moving their configuration into separate module files and updating the main profile to import these modules. This makes the configuration more modular and maintainable. Additionally, it removes the `vscodium.nix` module from the workstation profile.

**Profile modularization and configuration:**

* Moved the configuration for `claude-code` and `opencode` out of `ai.nix` and into their own dedicated module files (`claude.nix` and `opencode.nix`), and updated `ai.nix` to import these modules instead of directly adding the packages.
* Added a new `claude.nix` module that enables `claude-code` with custom settings, including model selection and explicit permissions/denials for shell commands and file access.
* Added a new `opencode.nix` module that enables `opencode` with specific settings such as disabling autoupdate and setting the TUI theme to "system".

**Workstation profile changes:**

* Removed the `vscodium.nix` module from the list of imports in `workstation.nix`, so `vscodium` will no longer be included in the workstation profile.