### PR TITLE
feat(vnc): max fps 60 and gpu enabled

### DIFF
--- a/users/profiles/vnc.nix
+++ b/users/profiles/vnc.nix
@@ -1,3 +1,4 @@
+{ lib, pkgs, ... }:
 {
   services.wayvnc = {
     enable = true;
@@ -13,6 +14,7 @@
   };
 
   systemd.user.services.wayvnc.Service = {
+    ExecStart = lib.mkForce "${lib.getExe pkgs.wayvnc} --max-fps=60 --gpu 0.0.0.0 5900";
     Restart = "always";
     RestartSec = 10;
   };


### PR DESCRIPTION
This pull request updates the VNC profile to explicitly set the `wayvnc` service to run at 60 frames per second, use the first GPU, and listen on all network interfaces on port 5900. This is achieved by forcing a custom `ExecStart` command in the user systemd service configuration.

Configuration changes:

* The `ExecStart` command for the `wayvnc` systemd user service is now forced to `${lib.getExe pkgs.wayvnc} --max-fps=60 --gpu 0.0.0.0 5900`, ensuring the service runs with the desired performance and network settings.
* Added the necessary arguments to the VNC profile module to support the above configuration.