### PR TITLE
feat(home-manager): add zellij

### DIFF
--- a/users/profiles/default.nix
+++ b/users/profiles/default.nix
@@ -12,6 +12,7 @@
     ./git.nix
     ./ssh.nix
     ./starship.nix
+    ./zellij.nix
     ./ai.nix
   ];
 

--- a/users/profiles/zellij.nix
+++ b/users/profiles/zellij.nix
@@ -1,0 +1,5 @@
+{
+  programs.zellij = {
+    enable = true;
+  };
+}


### PR DESCRIPTION
This pull request adds support for the Zellij terminal workspace to the user profile. The main changes involve enabling the Zellij program by including its configuration.

Terminal workspace support:

* Added `zellij.nix` to the list of user profile modules in `default.nix`, so the Zellij configuration is now part of the user environment.
* Created a new `zellij.nix` module that enables the `programs.zellij` option.