### PR TITLE
fix(zellij): .config state

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -59,6 +59,7 @@
         ".config/spotify"
         ".config/VSCodium"
         ".config/warcraftlogs"
+        ".config/zellij"
         ".factorio"
         ".gnupg"
         ".lmstudio"


### PR DESCRIPTION
This pull request makes a small update to the `profiles/state.nix` file by adding the `.config/zellij` directory to the managed state. This ensures that the configuration for Zellij is included alongside other application configs.