### PR TITLE
chore: fix typos

### DIFF
--- a/modules/tailscale-auth.nix
+++ b/modules/tailscale-auth.nix
@@ -58,7 +58,7 @@ in
 
   config = mkIf tsAuth.enable {
     systemd.services.tailscale-auth = {
-      description = "Tailscale automatic authentoication";
+      description = "Tailscale automatic authentication";
       wantedBy = [ "tailscaled.service" ];
       after = [ "tailscaled.service" ] ++ tsAuth.after;
       restartTriggers = [ tsAuthScript ];

--- a/profiles/greetd.nix
+++ b/profiles/greetd.nix
@@ -190,7 +190,7 @@ in
       greeting_msg = "Welcome back!";
     };
     GTK = {
-      curser_theme_name = lib.mkForce "Nordzy-cursors";
+      cursor_theme_name = lib.mkForce "Nordzy-cursors";
       font_name = lib.mkForce "Roboto Medium 14";
       icon_theme_name = lib.mkForce "Nordzy-dark";
       theme_name = lib.mkForce "Nordic-darker";

--- a/users/profiles/dunst.nix
+++ b/users/profiles/dunst.nix
@@ -16,11 +16,11 @@
         word_wrap = "yes";
         ignore_newline = "no";
         stack_duplicates = "yes";
-        hide_deplicates_count = "yes";
+        hide_duplicates_count = "yes";
         geometry = "300x50-15+49";
         shrink = "no";
         transparency = 5;
-        ide_threshold = 0;
+        idle_threshold = 0;
         monitor = 0;
         follow = "none";
         stick_history = "yes";

--- a/users/profiles/git.nix
+++ b/users/profiles/git.nix
@@ -27,7 +27,7 @@
         diff = "auto";
         status = "auto";
         branch = "auto";
-        interacive = "auto";
+        interactive = "auto";
         ui = true;
         pager = true;
       };

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -59,12 +59,12 @@ in
       "x-scheme-handler/about" = "firefox.desktop";
       "x-scheme-handler/unknown" = "firefox.desktop";
       "x-scheme-handler/chrome" = "firefox.desktop";
-      "application/x-exension-htm" = "firefox.desktop";
-      "application/x-exension-html" = "firefox.desktop";
-      "application/x-exension-shtml" = "firefox.desktop";
+      "application/x-extension-htm" = "firefox.desktop";
+      "application/x-extension-html" = "firefox.desktop";
+      "application/x-extension-shtml" = "firefox.desktop";
       "application/xhtml+xml" = "firefox.desktop";
-      "application/x-exension-xhtml" = "firefox.desktop";
-      "application/x-exension-xht" = "firefox.desktop";
+      "application/x-extension-xhtml" = "firefox.desktop";
+      "application/x-extension-xht" = "firefox.desktop";
     };
   };
 


### PR DESCRIPTION
This pull request consists of several minor typo corrections across multiple configuration files to improve accuracy and consistency. The changes fix spelling mistakes and incorrect key names, which helps prevent configuration errors and improves maintainability.

**Typo and key name corrections:**

* Fixed typo in the `description` field of the `tailscale-auth` systemd service (`authentoication` → `authentication`) in `modules/tailscale-auth.nix`.
* Corrected the GTK cursor theme key (`curser_theme_name` → `cursor_theme_name`) in `profiles/greetd.nix`.
* Fixed multiple typos in `users/profiles/dunst.nix`: `hide_deplicates_count` → `hide_duplicates_count` and `ide_threshold` → `idle_threshold`.
* Corrected a typo in the `git` profile (`interacive` → `interactive`) in `users/profiles/git.nix`.
* Fixed several typos in MIME type keys (`x-exension` → `x-extension`) in `users/profiles/workstation.nix`.