### PR TITLE
feat(vnc): lower restart sec systemd

### DIFF
--- a/users/profiles/vnc.nix
+++ b/users/profiles/vnc.nix
@@ -16,6 +16,6 @@
   systemd.user.services.wayvnc.Service = {
     ExecStart = lib.mkForce "${lib.getExe pkgs.wayvnc} --max-fps=60 --gpu 0.0.0.0 5900";
     Restart = "always";
-    RestartSec = 10;
+    RestartSec = 2;
   };
 }


### PR DESCRIPTION
This pull request makes a small adjustment to the `users/profiles/vnc.nix` configuration, reducing the restart delay for the `wayvnc` systemd user service from 10 seconds to 2 seconds. This change will allow the service to restart more quickly after a failure.