### PR TITLE
chore: remove cnf dbPath

### DIFF
--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -119,8 +119,6 @@ in
     vim = "nvim";
   };
 
-  programs.command-not-found.dbPath = "${./..}/programs.sqlite";
-
   security.sudo.extraConfig = ''
     Defaults  lecture="never"
   '';


### PR DESCRIPTION
This pull request makes a minor change to the `profiles/defaults.nix` file by removing the configuration for the command-not-found database path.