### PR TITLE
chore(flake): nixpkgs unstable instead of unstable-small

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -901,11 +901,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777250669,
-        "narHash": "sha256-lswnQkFAkciQwXO0u23wUVZvq6TABj6Kk/+Po4FJYW4=",
+        "lastModified": 1777258755,
+        "narHash": "sha256-EC07KwADRE2LdIk7vEDyAaD3I0ZUq24T9jQF9L0iEPk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4883af6edbdf222c66edb545d312f4e40030a2be",
+        "rev": "7f8bbc93d63401e41368d6ddc46a4f631610fa90",
         "type": "github"
       },
       "original": {
@@ -1628,16 +1628,16 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1777238095,
-        "narHash": "sha256-wyaAOqFhxYmtTb/Gb/+hegVJ3MnwOJjX9aqsQT3+R38=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c4073437f5ffeaeee270c37a2eddf370658d1332",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable-small",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1648,11 +1648,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1777250897,
-        "narHash": "sha256-9Q/kA33WFCyODlPhq9FSqvIRUYxKHgYz/SRI2NXCk74=",
+        "lastModified": 1777269952,
+        "narHash": "sha256-mgi1SWm8gvbc5+Ds3CsSR2PdVQDJcd4LIgqrAR1vhQY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8541d9f0cdb304ed06d5d4d07480067ff4cb5fc0",
+        "rev": "c7bf566f4d15389a44569565390acf5f7ff6d2e2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
     nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
     nixos-generators.url = "github:nix-community/nixos-generators";
     nixos-hardware.url = "github:nixos/nixos-hardware";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nur.url = "github:nix-community/NUR";
     pre-commit-hooks.inputs.flake-compat.follows = "flake-compat";
     pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
This pull request updates the `nixpkgs` input in the `flake.nix` file to track the `nixos-unstable` branch instead of `nixos-unstable-small`. This change will result in a broader set of packages being available from the NixOS package repository.

- Switched the `nixpkgs` input source from `nixos-unstable-small` to `nixos-unstable` in `flake.nix`, expanding the available package set.