### PR TITLE
fix(hyprlock): proper 24h date

### DIFF
--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -62,7 +62,7 @@ in
       label = [
         {
           monitor = "";
-          text = ''cmd[update:1000] echo "<span foreground='##660000'>"$(date +"%-H:%M")"</span>"'';
+          text = ''cmd[update:1000] echo "<span foreground='##660000'>"$(date +"%H:%M")"</span>"'';
           color = "rgba(102, 0, 0, 0.75)";
           font_size = 95;
           font_family = "JetBrains Mono Extrabold";


### PR DESCRIPTION
This pull request makes a small update to the time display format in the status bar configuration. The change updates the time format from a non-padded hour (`%-H:%M`) to a zero-padded hour (`%H:%M`) for consistency and improved readability.

* Changed the time format in the status bar label to use zero-padded hours (`%H:%M`) instead of non-padded hours (`%-H:%M`) in `users/profiles/hyprland.nix`.