### PR TITLE
fix(claude): set effort level

### DIFF
--- a/users/profiles/claude.nix
+++ b/users/profiles/claude.nix
@@ -3,6 +3,7 @@
     enable = true;
     settings = {
       model = "opus";
+      effortLevel = "medium";
       permissions = {
         allow = [
           "Bash(git diff:*)"


### PR DESCRIPTION
This pull request makes a small configuration update to the `users/profiles/claude.nix` file. The change sets the `effortLevel` setting to `"medium"` for the relevant profile.

- Added `effortLevel = "medium";` to the profile settings in `users/profiles/claude.nix`.