### PR TITLE
fix: resolve home-manager evaluation warnings

### DIFF
--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -112,6 +112,7 @@ in
   };
 
   wayland.windowManager.hyprland.enable = true;
+ wayland.windowManager.hyprland.configType = "hyprlang";
   wayland.windowManager.hyprland.extraConfig = ''
     bind=$mod,escape,submap,(p)oweroff, (s)uspend, (h)ibernate, (r)eboot, (l)ogout
     submap=(p)oweroff, (s)uspend, (h)ibernate, (r)eboot, (l)ogout
@@ -299,7 +300,6 @@ in
 
     layerrule = [
       "match:workspace waybar, blur off"
-      "match:workspace waybar, ignore_alpha on"
     ];
 
     input = {

--- a/users/profiles/ssh.nix
+++ b/users/profiles/ssh.nix
@@ -7,31 +7,29 @@
     enable = true;
     enableDefaultConfig = false;
 
-    matchBlocks = {
+    settings = {
       "*" = {
-        controlPersist = "30m";
-        controlMaster = "auto";
-        controlPath = "~/.ssh/master-%r@%n:%p";
-        serverAliveInterval = 60;
-        serverAliveCountMax = 3;
-        hashKnownHosts = false;
-        forwardAgent = true;
-        addKeysToAgent = "no";
-        compression = false;
+        ControlPersist = "30m";
+        ControlMaster = "auto";
+        ControlPath = "~/.ssh/master-%r@%n:%p";
+        ServerAliveInterval = 60;
+        ServerAliveCountMax = 3;
+        HashKnownHosts = false;
+        ForwardAgent = true;
+        AddKeysToAgent = "no";
+        Compression = false;
       };
       "github github.com" = {
-        hostname = "github.com";
-        user = "git";
-        forwardAgent = false;
-        extraOptions = {
-          preferredAuthentications = "publickey";
-          controlMaster = "no";
-          controlPath = "none";
-        };
+        Hostname = "github.com";
+        User = "git";
+        ForwardAgent = false;
+        PreferredAuthentications = "publickey";
+        ControlMaster = "no";
+        ControlPath = "none";
       };
       "framenix" = {
-        user = "nemko";
-        forwardAgent = true;
+        User = "nemko";
+        ForwardAgent = true;
       };
     };
   };


### PR DESCRIPTION
- Set hyprland configType to 'hyprlang' to silence default value warning
- Migrate ssh matchBlocks to settings and inline extraOptions
- Remove deprecated layerrule ignore_alpha from hyprland config