### PR TITLE
Fix DP-3 scale so right monitor edge aligns

### DIFF
--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -162,7 +162,7 @@ in
         ]
       else
         [
-          "DP-3, preferred, 0x0, 1.33"
+          "DP-3, preferred, 0x0, 1.333333"
           "DP-4, preferred, -1440x0, 1, transform, 1"
           #"DP-4, disable"
           "DP-5, preferred, 2880x0, 1, transform, 3"


### PR DESCRIPTION
## Problem
A few pixels on the right monitor (DP-5) were hidden.

## Cause
DP-3 (3840px wide) was set to scale `1.33`, giving it a logical width of `3840 / 1.33 ≈ 2887`. DP-5 is positioned at `x=2880`, so DP-5's leftmost ~7 logical pixels overlapped underneath DP-3.

## Fix
Use `1.333333` (i.e. 4/3) so DP-3's logical width is exactly `2880`, aligning cleanly with DP-5's position — which was clearly the intended seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)