### PR TITLE
nvidia: pin driver to `latest` (610.43.02) for RTX 5090 / kernel 7.0

### DIFF
--- a/profiles/hardware/nvidia.nix
+++ b/profiles/hardware/nvidia.nix
@@ -16,7 +16,9 @@
     powerManagement.enable = false;
     powerManagement.finegrained = false;
     nvidiaSettings = true;
-    package = config.boot.kernelPackages.nvidiaPackages.beta;
+    # RTX 5090 (Blackwell) needs a recent driver; `beta` (595.x) fails to build
+    # against linuxPackages_latest (kernel 7.0). `latest` tracks the newest packaged driver.
+    package = config.boot.kernelPackages.nvidiaPackages.latest;
   };
 
   #boot.initrd.kernelModules = [ "nvidia" ];


### PR DESCRIPTION
## Problem
`nixos-rebuild` fails building the NVIDIA kernel module on `nixbox`:

```
././common/inc/nv-linux.h:1730:10: fatal error: linux/of_gpio.h: No such file or directory
```

`linux/of_gpio.h` was removed from mainline, and the `beta` driver
(**595.45.04**) still `#include`s it, so it can't compile against
`linuxPackages_latest` (**kernel 7.0.10**). The GPU is an **RTX 5090
(GB202, Blackwell)**, which additionally needs a recent open-module driver.

## Fix
Switch `hardware.nvidia.package` from `nvidiaPackages.beta` → `nvidiaPackages.latest`
(**610.43.02**), which builds against kernel 7.0 and supports Blackwell. `open = true`
is kept — it is mandatory for Blackwell.

`latest` (rather than a hard version pin) suits this bleeding-edge host and the repo's
auto flake-input updates: it self-heals against future kernel bumps instead of lagging.

## Verification
- `nix build .#nixosConfigurations.nixbox.config.hardware.nvidia.package` — builds
  clean (610.43.02), no `of_gpio.h` error.
- After reboot, `nvidia-smi` / `modinfo nvidia` should report **610.43.02**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)