### PR TITLE
fix(theme): restore system-wide dark mode

### DIFF
--- a/profiles/greetd.nix
+++ b/profiles/greetd.nix
@@ -172,7 +172,7 @@ in
   environment.systemPackages = [
     pkgs.nordic
     pkgs.nordzy-cursor-theme
-    pkgs.arc-icon-theme
+    pkgs.nordzy-icon-theme
   ];
 
   programs.regreet.settings = {

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -120,25 +120,24 @@ in
 
   xdg.portal = {
     enable = true;
-    wlr.enable = true;
-    extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
-    config =
-      let
-        wlrConf = {
-          default = [
-            "wlr"
-            "gtk"
-          ];
-          "org.freedesktop.impl.portal.Secret" = [ "gnome-keyring" ];
-        };
-      in
-      {
-        common = {
-          default = [ "gtk" ];
-          "org.freedesktop.impl.portal.Secret" = [ "gnome-keyring" ];
-        };
-        sway = wlrConf;
+    extraPortals = [
+      pkgs.xdg-desktop-portal-gtk
+      pkgs.xdg-desktop-portal-hyprland
+    ];
+    # Keyed off XDG_CURRENT_DESKTOP lowercased, so this must say hyprland.
+    config = {
+      common = {
+        default = [ "gtk" ];
+        "org.freedesktop.impl.portal.Secret" = [ "gnome-keyring" ];
       };
+      hyprland = {
+        default = [
+          "hyprland"
+          "gtk"
+        ];
+        "org.freedesktop.impl.portal.Secret" = [ "gnome-keyring" ];
+      };
+    };
   };
 
   fonts.packages = with pkgs; [

--- a/users/profiles/hyprland.nix
+++ b/users/profiles/hyprland.nix
@@ -94,7 +94,6 @@ in
     MOZ_USE_XINPUT2 = "1";
     XCURSOR_THEME = xcursor_theme;
     XCURSOR_SIZE = "24";
-    QT_STYLE_OVERRIDE = lib.mkForce "gtk";
     _JAVA_AWT_WM_NONREPARENTING = "1";
     NIXOS_OZONE_WL = "1";
   };

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -80,6 +80,8 @@ in
 
   home.sessionVariables.XCURSOR_THEME = gtk.cursorTheme.name;
 
+  dconf.settings."org/gnome/desktop/interface".color-scheme = "prefer-dark";
+
   gtk = {
     enable = true;
     font = {
@@ -91,13 +93,15 @@ in
       name = "Nordzy-cursors";
     };
     iconTheme = {
-      package = pkgs.arc-icon-theme;
+      package = pkgs.nordzy-icon-theme;
       name = "Nordzy-dark";
     };
     theme = {
       package = pkgs.nordic;
       name = "Nordic-darker";
     };
+    gtk3.extraConfig.gtk-application-prefer-dark-theme = true;
+    gtk4.extraConfig.gtk-application-prefer-dark-theme = true;
     gtk4.theme = null;
   };
 }


### PR DESCRIPTION
Dark mode broke on the 2026-08-09 rebuild (system generation 301 -> 302). No theming file had changed since April; the regression came in with the nixpkgs bump, which carried firefox 152.0.6 -> 153.0.1 and electron 42.5.1 -> 43.2.0.

The config only ever set a dark GTK *theme name* (Nordic-darker) and never emitted a dark-mode preference. Firefox and Chromium/Electron used to infer dark by sniffing the GTK theme's colors; the new versions read the XDG appearance portal instead, and ours reported "no preference":

  $ busctl --user call org.freedesktop.portal.Desktop \
      /org/freedesktop/portal/desktop org.freedesktop.portal.Settings \
      ReadOne ss org.freedesktop.appearance color-scheme
  v u 0

xdg-desktop-portal-gtk derives that from dconf org/gnome/desktop/interface color-scheme, which nothing wrote. GTK3 apps stayed dark because they load Nordic-darker directly, which is why the breakage looked partial.

Set color-scheme = "prefer-dark" so the portal advertises dark, plus gtk-application-prefer-dark-theme in gtk3/gtk4 settings.ini for apps that skip the portal. gtk4.theme stays null (#316): libadwaita picks dark up from color-scheme, and Nordic's GTK4 port is incomplete.

Three adjacent breakages found in the same code:

- iconTheme named Nordzy-dark but pulled arc-icon-theme, which ships only Adwaita/Arc/gnome/hicolor/Moka. Nordzy-dark was absent from the profile entirely and icons were falling back to hicolor. Same swap in greetd.
- QT_STYLE_OVERRIDE was force-set to "gtk", a qt5-styleplugins style that is not installed, overriding qt.style.name = adwaita-dark. Dropped; the home-manager qt module already sets the variable.
- xdg.portal.config keyed the wlr backend under "sway" while the session is Hyprland, so that section never applied. Renamed to hyprland (the key is XDG_CURRENT_DESKTOP lowercased) and wired xdg-desktop-portal-hyprland into extraPortals. The hyprland backend implements only Screenshot/ScreenCast/ GlobalShortcuts/InputCapture, so Settings still falls through to gtk. wlr.enable dropped as redundant on a Hyprland-only session.

Verified in the built closure: hm-dconf.ini gains color-scheme='prefer-dark', both settings.ini gain gtk-application-prefer-dark-theme=true, hyprland-portals.conf is generated, and Nordzy-dark now exists in the closure.