### PR TITLE
fix(dms): make notification popups opaque

### DIFF
--- a/users/profiles/dank-material-shell.nix
+++ b/users/profiles/dank-material-shell.nix
@@ -93,7 +93,7 @@ in
       useAutoLocation = true;
       weatherEnabled = true;
       cornerRadius = 0;
-      popupTransparency = 0.65;
+      popupTransparency = 1.0;
       barElevationEnabled = false;
       m3ElevationEnabled = false;
       notificationCompactMode = true;


### PR DESCRIPTION
Notification popups under Dank Material Shell were see-through, with text sitting directly over whatever window was beneath.

## Cause

`Modules/Notifications/Popup/NotificationPopup.qml` paints the popup surface with `Theme.readableSurface`, which is `withAlpha(surfaceContainer, popupTransparency)`. We set `popupTransparency = 0.65`, and nothing was frosting the layer underneath:

- DMS's own `BlurService` requires `blurEnabled` (unset, defaults `false`) **and** compositor `ext-background-effect-v1` support.
- Hyprland's `decoration.blur` does not apply to layer surfaces without an explicit `layer_rule`, and we have none.

So the card was literally 65% alpha over the window below.

## Fix

Raise `popupTransparency` to `1.0`. DMS 1.5.3 has no notification-only transparency override — `SettingsSpec.js` only defines per-surface overrides for notepad, dock, desktop clock and system monitor — so this is global: the control center, launcher and notification center go opaque too. The bar keeps its own separate `transparency = 0.65`.

## Verification

- Evaluates clean; the rendered `settings.json` contains `"popupTransparency": 1.0`, which `percentToUnit` (`v > 1 ? v / 100 : v`) leaves as fully opaque rather than 1%.
- Not yet rebuilt/switched on hardware — worth a `notify-send` over a bright window after switching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)