### PR TITLE
fix(kernel): pin to 7.1 for Cilium compatibility

### DIFF
--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -82,7 +82,10 @@ in
 
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  # Pinned to 7.1: kernel 7.2 breaks Cilium's BPF probing (bpf_set_retval /
+  # FnSetRetval verifier rejection) - see https://github.com/cilium/cilium/issues/48016.
+  # Revert to pkgs.linuxPackages_latest once Cilium ships a fix.
+  boot.kernelPackages = pkgs.linuxPackages_7_1;
   boot.initrd.availableKernelModules = [
     "xhci_pci"
     "nvme"


### PR DESCRIPTION
Kernel 7.2 breaks Cilium's BPF feature probing: the agent fails to start with "detect support for FnSetRetval for program type CGroupSock: load program: invalid argument: 0: (85) call bpf_set_retval#187: R1 is not a scalar". See https://github.com/cilium/cilium/issues/48016.

All hosts run k3s with Cilium as the kube-proxy replacement, so a broken agent means no cluster networking. linuxPackages_7_1 resolves to 7.1.8 on the current lock, identical to linuxPackages_latest today, so this is a no-op now and only prevents the next flake update from rolling onto 7.2.