### PR TITLE
feat(workstation): add bambu-studio

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -40,6 +40,7 @@
         ".cache/zellij"
         ".cargo"
         ".claude"
+        ".config/BambuStudio"
         ".config/DankMaterialShell"
         ".config/LM Studio"
         ".config/Signal"

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -33,6 +33,12 @@ in
   hardware.bluetooth.enable = true;
   networking.wireless.iwd.enable = true;
 
+  # Bambu Studio LAN-mode printer discovery (SSDP).
+  networking.firewall.allowedUDPPorts = [
+    1990
+    2021
+  ];
+
   environment.pathsToLink = [ "/etc/gconf" ];
 
   security.pam.services.gdm.enableGnomeKeyring = true; # load gnome-keyring at startup

--- a/users/profiles/bambu-studio.nix
+++ b/users/profiles/bambu-studio.nix
@@ -1,0 +1,11 @@
+{ pkgs, osConfig, ... }:
+{
+  home.packages = [
+    (pkgs.bambu-studio.override {
+      # 3D viewport is blank on the NVIDIA proprietary GL stack; this routes
+      # rendering through Mesa + zink instead.
+      # https://github.com/NixOS/nixpkgs/issues/498311
+      withNvidiaGLWorkaround = builtins.elem "nvidia" osConfig.services.xserver.videoDrivers;
+    })
+  ];
+}

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -15,6 +15,7 @@ in
     ./default.nix
   ]
   ++ [
+    ./bambu-studio.nix
     ./dank-material-shell.nix
     ./faugus.nix
     ./hyprland.nix


### PR DESCRIPTION
Adds the Bambu Lab slicer to all workstation hosts (framenix, manix, nixbox).

There was no slicer / 3D-printing software in the repo at all, so this is a from-scratch addition rather than a package-list tweak. Three things made it more than a one-liner:

**Persistence** — root is tmpfs and only what `profiles/state.nix` lists survives. Bambu Studio downloads a proprietary networking plugin on first launch and dlopens it (this is exactly why the nixpkgs package is marked `unfree`; see the license comment in `pkgs/by-name/ba/bambu-studio/package.nix`). Without persisting its datadir, that plugin, the printer presets and the login all vanish on reboot. `.config/BambuStudio` is the whole datadir — `plugins/`, `user/`, `system/`, `cache/`, `log/` — so one entry covers it. Credentials go to the keyring via libsecret, and `.local/share/keyrings` is already persisted.

**Firewall** — LAN-mode discovery is SSDP on UDP 1990/2021 and nothing was open. This is the first `allowedUDPPorts` in the repo.

**NVIDIA** — `nixbox` is on the proprietary driver via `profiles/hardware/x570.nix`, where the 3D viewport renders blank ([nixpkgs#498311](https://github.com/NixOS/nixpkgs/issues/498311)). The package has a `withNvidiaGLWorkaround` flag for it; keyed off `osConfig.services.xserver.videoDrivers` so framenix/manix are unaffected, rather than adding a new hostvar.

`allowUnfree` is already global in `flake/setup.nix`, so the unfree license needs no extra handling.

## Verification

- `statix` clean, `nixfmt` clean, `deadnix` reports nothing on the new file.
- All three workstation configs evaluate to a toplevel derivation.
- `nixbox` gets `MESA_LOADER_DRIVER_OVERRIDE=zink` / `GALLIUM_DRIVER=zink` in its wrapper args; `framenix` does not — confirmed by diffing the two derivations.
- `networking.firewall.allowedUDPPorts` evaluates to `[1990 2021]`.
- Impermanence generates the `home-nemko-.config-BambuStudio.mount` bind mount.

Not yet done: a full source build and a real launch. The package is not in any binary cache (unfree, so Hydra skips it), and the build was too long to complete here. The end-to-end test after switching is: launch it, let the network plugin download, add the printer in LAN mode, then reboot and confirm the printer, presets and login are still there and the plugin is not re-downloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)