### PR TITLE
feat(nix): adopt nh for rebuilds and garbage collection

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -4,44 +4,18 @@ alias help := default
 
 default:
   @just --list -f {{justfile()}} -d {{invocation_directory()}}
-  @if (echo {{invocation_directory()}} | str contains "cronge") { echo "\n    lint\n    check"}
 
-search query:
-  @nix search nixpkgs {{query}} --json | from json | transpose | flatten | select column0 version description | rename --column { column0: attribute }
-
-gc:
-  @nix-collect-garbage -d
-
-upgrade flake="github:tabasco0322/nixbix":
-  @rm -rf ~/.cache/nix/fetcher-cache-v1.sqlite*
-  @nixos-rebuild boot --flake '{{flake}}' --use-remote-sudo -L
-  @if (echo initrd kernel kernel-modules | all { |it| (readlink $"/run/booted-system/($it)") != (readlink $"/nix/var/nix/profiles/system/($it)") }) { echo "The system must be rebooted for the changes to take effect" } else { nixos-rebuild switch --flake '{{flake}}' --use-remote-sudo -L }
-
-switch-remote host="":
-  nixos-rebuild switch --flake '.#{{host}}' --target-host '{{host}}' --use-remote-sudo -L
-
-build flake="github:tabasco0322/nixbix":
-  @nixos-rebuild build --flake '{{flake}}' --use-remote-sudo -L
-
-[private]
-echo +args:
-  echo '{{args}}'
-
-[private]
 lint:
   @echo '-------- [Linting] ---------'
   @let out = (statix check . | complete); if ($out.exit_code > 0) { let span = (metadata $out).span; error make {msg: "Linting failed", label: {text: $out.stdout, span: $span}} } else { print "Lint ok\n\n"; print $out.stdout }
 
-[private]
 dead:
   @echo '-------- [Check for dead code] ---------'
   @let out = (deadnix -f . | complete); if ($out.exit_code > 0) { let span = (metadata $out).span; error make {msg: "Dead code check failed", label: {text: $out.stdout, span: $span}} } else { print "No dead code\n\n"; print $out.stdout }
 
-[private]
 dscheck:
   @echo '-------- [Flake checker] ---------'
   @let out = (nix run github:DeterminateSystems/flake-checker | complete); if ($out.exit_code > 0) { let span = (metadata $out).span; error make {msg: "Flake checker failed", label: {text: $out.stdout, span: $span}} } else { print "Flake is good\n\n"; print $out.stdout }
 
-[private]
 check:
   @nix flake check --impure # impure because of devenv

--- a/README.md
+++ b/README.md
@@ -53,10 +53,19 @@
     ```
 
 ### Test build
-* ```nixos-rebuild build --flake .#$hostname ```
+* ```nh os build```
+    * *`NH_FLAKE` is preset on workstations, so the flake path can be omitted.
+      Otherwise: `nh os build /path/to/nixbix -H $hostname`*
 
 ### Switch to build
-* ```nixos-rebuild switch --flake .#$hostname --sudo```
+* ```nh os switch --ask```
+    * *Shows a diff of what changed and asks before activating. `nh` elevates
+      itself, so no `sudo` is needed.*
+
+### Garbage collection
+* ```nh clean all --no-direnv```
+    * *Runs daily via the `nh-clean` timer; this is only for on-demand cleanup.
+      `--no-direnv` preserves nix-direnv gcroots.*
 
 ### Build on Mac
 

--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -29,13 +29,20 @@ in
 
     nixPath = [ "nixpkgs=${inputs.nixpkgs}" ];
 
-    gc = {
-      automatic = true;
-      dates = "daily";
-      options = "--delete-older-than 7d";
-    };
+    optimise.automatic = true;
 
     package = pkgs.nix;
+  };
+
+  # Garbage collection is handled by nh clean, not nix.gc.automatic; enabling
+  # both conflicts. --no-direnv keeps nh from wiping nix-direnv gcroots.
+  programs.nh = {
+    enable = true;
+    clean = {
+      enable = true;
+      dates = "daily";
+      extraArgs = "--keep 5 --keep-since 7d --no-direnv";
+    };
   };
 
   environment.systemPackages = [

--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -86,6 +86,7 @@
         ".local/share/zoxide"
         ".local/state/DankMaterialShell"
         ".local/state/pipewire/media-session.d"
+        ".local/state/nh"
         ".local/state/opencode"
         ".local/state/wireplumber"
         ".mail"

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -75,6 +75,10 @@ in
 
   programs.ssh.startAgent = true;
 
+  # Local checkout, so a bare `nh os switch` picks up uncommitted changes.
+  # Only workstations have one; servers are deployed to remotely.
+  programs.nh.flake = "/home/${adminUser.name}/git/nixbix";
+
   programs.gamemode.enable = true;
 
   services.pcscd.enable = true;


### PR DESCRIPTION
nh (nix-community/nh) reimplements nixos-rebuild, nix-collect-garbage and nix search in one CLI, adding a nix-output-monitor build tree, a dix diff of what changed before activation, and self-elevation.

- Enable programs.nh everywhere and replace nix.gc.automatic with programs.nh.clean. The two conflict, so they move in one commit. --keep 5 guarantees a rollback target survives a quiet week, which --delete-older-than 7d did not. --no-direnv is required: nh cleans gcroots by default and would otherwise wipe nix-direnv's caches nightly.
- Add nix.optimise.automatic, which was missing entirely.
- Set NH_FLAKE to the local checkout on workstations only, so a bare `nh os switch` picks up uncommitted changes. Servers are deployed to remotely and have no clone.
- Persist ~/.local/state/nh for the nh search prs token.
- Drop the Justfile's search/gc/upgrade/build/switch-remote recipes. They have not been invoked once in 16 months of shell history and nh replaces them directly. The remaining lint recipes lose [private] so `just` lists something again, along with a cwd check that never matched.

CI is unaffected: it only calls `cronge -- lint` and `cronge -- check`, both untouched, and cronge's runtime closure is byte-identical.